### PR TITLE
Add CLI and vault regression tests

### DIFF
--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -1,7 +1,5 @@
 from types import SimpleNamespace
 
-import pytest
-
 from src.cli.main import cmd_auth
 from src.core.secret_vault import SecretVault
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from src.cli.main import cmd_init, cmd_process, cmd_setup, cmd_status
+
+
+class DummyManager:
+    def __init__(self, workspace: Path):
+        self.owner = "owner"
+        self.repo = "repo"
+        self.workspace_path = workspace
+        self.setup_called = False
+        self.process_issue_called_with = None
+
+    def setup_repository(self):
+        self.setup_called = True
+
+    def process_issue(self, issue_number: int):
+        self.process_issue_called_with = issue_number
+        return {"status": "completed", "phases_completed": ["pm_agent"]}
+
+
+def test_cmd_setup_success(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace(skip_docs=False)
+    assert cmd_setup(manager, args) == 0
+    assert manager.setup_called
+
+
+def test_cmd_setup_error(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+
+    def fail():
+        raise RuntimeError("boom")
+
+    manager.setup_repository = fail
+    args = SimpleNamespace(skip_docs=False)
+    assert cmd_setup(manager, args) == 1
+
+
+def test_cmd_process_success(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace(issue=1)
+    assert cmd_process(manager, args) == 0
+    assert manager.process_issue_called_with == 1
+
+
+def test_cmd_process_error(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    manager.process_issue = lambda n: {"error": "bad"}
+    args = SimpleNamespace(issue=1)
+    assert cmd_process(manager, args) == 1
+
+
+def test_cmd_init_success(monkeypatch, tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    monkeypatch.setattr("src.cli.main._create_web_template", lambda p: None)
+    monkeypatch.setattr("src.cli.main._create_api_template", lambda p: None)
+    monkeypatch.setattr("src.cli.main._create_cli_template", lambda p: None)
+    monkeypatch.setattr("src.cli.main._create_library_template", lambda p: None)
+    args = SimpleNamespace(template="web")
+    assert cmd_init(manager, args) == 0
+    assert manager.setup_called
+
+
+def test_cmd_init_error(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+
+    def fail():
+        raise RuntimeError("boom")
+
+    manager.setup_repository = fail
+    args = SimpleNamespace(template="web")
+    assert cmd_init(manager, args) == 1
+
+
+def test_cmd_status(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace(issue=None)
+    assert cmd_status(manager, args) == 0
+    args_issue = SimpleNamespace(issue=5)
+    assert cmd_status(manager, args_issue) == 0

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,7 +1,5 @@
-from types import SimpleNamespace
 from pathlib import Path
-
-import pytest
+from types import SimpleNamespace
 
 from src.cli.main import cmd_init, cmd_process, cmd_setup, cmd_status
 

--- a/tests/test_pat_scopes.py
+++ b/tests/test_pat_scopes.py
@@ -33,3 +33,12 @@ def test_validate_github_token_scopes(monkeypatch):
     monkeypatch.setattr("requests.get", bad_get)
     with pytest.raises(ValueError):
         validate_github_token_scopes("token")
+
+
+def test_get_github_token_scopes_error(monkeypatch):
+    def bad_get(url: str, headers=None, timeout=10):
+        return DummyResponse(401, "")
+
+    monkeypatch.setattr("requests.get", bad_get)
+    with pytest.raises(ValueError):
+        get_github_token_scopes("token")

--- a/tests/test_secret_vault.py
+++ b/tests/test_secret_vault.py
@@ -23,6 +23,7 @@ def test_env_override(tmp_path: Path, monkeypatch):
 
 # additional tests
 
+
 def test_delete_secret(tmp_path: Path):
     vault_path = tmp_path / "vault.json"
     key_path = tmp_path / "vault.key"

--- a/tests/test_secret_vault.py
+++ b/tests/test_secret_vault.py
@@ -19,3 +19,19 @@ def test_env_override(tmp_path: Path, monkeypatch):
     vault.set_secret("github_token", "secret")
     monkeypatch.setenv("GITHUB_TOKEN", "envtoken")
     assert vault.get_secret("github_token") == "envtoken"
+
+
+# additional tests
+
+def test_delete_secret(tmp_path: Path):
+    vault_path = tmp_path / "vault.json"
+    key_path = tmp_path / "vault.key"
+    vault = SecretVault(vault_path=vault_path, key_path=key_path)
+    vault.set_secret("github_token", "secret")
+    vault.delete_secret("github_token")
+    assert vault.get_secret("github_token") is None
+
+
+def test_get_missing_secret(tmp_path: Path):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    assert vault.get_secret("missing") is None


### PR DESCRIPTION
## Summary
- expand test coverage for secret vault operations
- test PAT scope retrieval error handling
- add tests for CLI command helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ae859f60832d8a9fea49d127d908