### PR TITLE
Implement Issue Hierarchy Manager

### DIFF
--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -1,3 +1,4 @@
 from .task_manager import TaskManager
+from .hierarchy_manager import HierarchyManager, IssueNode
 
-__all__ = ["TaskManager"]
+__all__ = ["TaskManager", "HierarchyManager", "IssueNode"]

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -1,4 +1,4 @@
-from .task_manager import TaskManager
 from .hierarchy_manager import HierarchyManager, IssueNode
+from .task_manager import TaskManager
 
 __all__ = ["TaskManager", "HierarchyManager", "IssueNode"]

--- a/src/tasks/hierarchy_manager.py
+++ b/src/tasks/hierarchy_manager.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ..github.issue_manager import IssueManager, Issue
+
+
+@dataclass
+class IssueNode:
+    """Represents an issue in the hierarchy tree."""
+
+    number: int
+    title: str
+    labels: List[str]
+    body: str = ""
+    parent: Optional[int] = None
+    children: List[int] = field(default_factory=list)
+
+
+class HierarchyManager:
+    """Manage Epic → Feature → Task → Sub-task relationships."""
+
+    def __init__(self, issue_manager: IssueManager, orphan_threshold: int = 3) -> None:
+        self.issue_manager = issue_manager
+        self.orphan_threshold = orphan_threshold
+
+    # ------------------------------------------------------------------
+    def _parse_parent(self, body: str) -> Optional[int]:
+        """Extract parent issue number from body text.
+
+        Looks for lines like ``Parent: #12``.
+        """
+        for line in body.splitlines():
+            line = line.strip()
+            if line.lower().startswith("parent:"):
+                try:
+                    return int(line.split("#", 1)[1])
+                except (IndexError, ValueError):
+                    return None
+        return None
+
+    def build_tree(self) -> Dict[int, IssueNode]:
+        """Build hierarchy tree for open issues."""
+        issues = self.issue_manager.list_issues(state="open")
+        nodes: Dict[int, IssueNode] = {}
+        for issue in issues:
+            labels = [
+                lbl["name"] if isinstance(lbl, dict) and "name" in lbl else lbl
+                for lbl in issue.get("labels", [])
+            ]
+            node = IssueNode(
+                number=issue["number"],
+                title=issue.get("title", ""),
+                labels=labels,
+                body=issue.get("body", ""),
+            )
+            node.parent = self._parse_parent(node.body)
+            nodes[node.number] = node
+
+        # populate children
+        for node in nodes.values():
+            if node.parent and node.parent in nodes:
+                nodes[node.parent].children.append(node.number)
+        return nodes
+
+    # ------------------------------------------------------------------
+    def find_orphans(self, nodes: Dict[int, IssueNode]) -> List[IssueNode]:
+        """Return tasks or subtasks without parents."""
+        orphans = []
+        for node in nodes.values():
+            if any(
+                lbl in node.labels for lbl in ("feature", "task", "sub-task", "subtask")
+            ):
+                if not node.parent:
+                    orphans.append(node)
+        return orphans
+
+    def ensure_parents(self, nodes: Dict[int, IssueNode]) -> List[int]:
+        """Auto-create missing parents for orphaned nodes.
+
+        Returns a list of newly created issue numbers.
+        """
+        created: List[int] = []
+        for node in list(nodes.values()):
+            if not node.parent:
+                if "feature" in node.labels:
+                    title = f"Auto-created Epic for {node.title}"
+                    issue = Issue(
+                        title=title, body="", labels=["epic"], epic_parent=None
+                    )
+                    new_num = self.issue_manager.create_issue(issue)
+                    if new_num:
+                        node.parent = new_num
+                        created.append(new_num)
+                        nodes[new_num] = IssueNode(
+                            number=new_num, title=title, labels=["epic"]
+                        )
+                elif (
+                    "task" in node.labels
+                    and "sub-task" not in node.labels
+                    and "subtask" not in node.labels
+                ):
+                    title = f"Auto-created Feature for {node.title}"
+                    issue = Issue(
+                        title=title,
+                        body=f"Parent: #{node.number}",
+                        labels=["feature"],
+                        epic_parent=None,
+                    )
+                    new_num = self.issue_manager.create_issue(issue)
+                    if new_num:
+                        node.parent = new_num
+                        created.append(new_num)
+                        nodes[new_num] = IssueNode(
+                            number=new_num, title=title, labels=["feature"]
+                        )
+                elif "sub-task" in node.labels or "subtask" in node.labels:
+                    title = f"Auto-created Task for {node.title}"
+                    issue = Issue(
+                        title=title,
+                        body=f"Parent: #{node.number}",
+                        labels=["task"],
+                        epic_parent=None,
+                    )
+                    new_num = self.issue_manager.create_issue(issue)
+                    if new_num:
+                        node.parent = new_num
+                        created.append(new_num)
+                        nodes[new_num] = IssueNode(
+                            number=new_num, title=title, labels=["task"]
+                        )
+        return created
+
+    # ------------------------------------------------------------------
+    def warn_on_orphans(self, nodes: Dict[int, IssueNode]) -> List[IssueNode]:
+        """Return list of orphans if count exceeds threshold."""
+        orphans = self.find_orphans(nodes)
+        if len(orphans) >= self.orphan_threshold:
+            return orphans
+        return []
+
+    def visualize(self, nodes: Dict[int, IssueNode]) -> str:
+        """Return a simple text tree representation."""
+        lines: List[str] = []
+
+        def _walk(num: int, depth: int = 0) -> None:
+            node = nodes[num]
+            indent = "  " * depth
+            lines.append(f"{indent}- {node.title} (# {node.number})")
+            for child in node.children:
+                _walk(child, depth + 1)
+
+        roots = [n.number for n in nodes.values() if not n.parent]
+        for r in sorted(roots):
+            _walk(r, 0)
+        return "\n".join(lines)

--- a/src/tasks/hierarchy_manager.py
+++ b/src/tasks/hierarchy_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from ..github.issue_manager import IssueManager, Issue
+from ..github.issue_manager import Issue, IssueManager
 
 
 @dataclass

--- a/tests/test_hierarchy_manager.py
+++ b/tests/test_hierarchy_manager.py
@@ -1,5 +1,5 @@
-from src.tasks.hierarchy_manager import HierarchyManager
 from src.github.issue_manager import Issue
+from src.tasks.hierarchy_manager import HierarchyManager
 
 
 class DummyIssueManager:

--- a/tests/test_hierarchy_manager.py
+++ b/tests/test_hierarchy_manager.py
@@ -1,0 +1,106 @@
+from src.tasks.hierarchy_manager import HierarchyManager
+from src.github.issue_manager import Issue
+
+
+class DummyIssueManager:
+    def __init__(self, issues):
+        self._issues = issues
+        self.created = []
+
+    def list_issues(self, state="open"):
+        return self._issues
+
+    def create_issue(self, issue: Issue, milestone_number=None):
+        num = 100 + len(self.created)
+        self.created.append((num, issue))
+        return num
+
+
+def _make_issue(num, label, body=""):
+    return {
+        "number": num,
+        "title": f"Issue {num}",
+        "labels": [label],
+        "body": body,
+    }
+
+
+def test_build_tree_and_auto_create_parents():
+    issues = [_make_issue(1, "feature"), _make_issue(2, "task", "Parent: #1")]
+    dummy = DummyIssueManager(issues)
+    hm = HierarchyManager(dummy)
+    nodes = hm.build_tree()
+    created = hm.ensure_parents(nodes)
+    # A new epic should be created for the feature without parent
+    assert created
+    assert dummy.created[0][1].labels == ["epic"]
+    # After creation parent should be set
+    assert nodes[1].parent == 100
+
+
+def test_find_orphans():
+    issues = [
+        _make_issue(1, "task"),
+        _make_issue(2, "task"),
+        _make_issue(3, "task"),
+        _make_issue(4, "task"),
+    ]
+    dummy = DummyIssueManager(issues)
+    hm = HierarchyManager(dummy, orphan_threshold=3)
+    nodes = hm.build_tree()
+    orphans = hm.warn_on_orphans(nodes)
+    assert len(orphans) == 4
+
+
+def test_subtask_parent_creation_and_visualize():
+    issues = [
+        _make_issue(1, "sub-task"),
+    ]
+    dummy = DummyIssueManager(issues)
+    hm = HierarchyManager(dummy)
+    nodes = hm.build_tree()
+    created = hm.ensure_parents(nodes)
+    # Should create a task parent
+    assert created
+    assert dummy.created[0][1].labels == ["task"]
+    text = hm.visualize(nodes)
+    assert "Issue 1" in text
+
+
+def test_build_tree_relationships_and_visualize():
+    issues = [
+        _make_issue(1, "epic"),
+        _make_issue(2, "feature", "Parent: #1"),
+        _make_issue(3, "task", "Parent: #2"),
+        _make_issue(4, "sub-task", "Parent: #3"),
+    ]
+    hm = HierarchyManager(DummyIssueManager(issues))
+    nodes = hm.build_tree()
+
+    assert nodes[2].parent == 1
+    assert nodes[3].parent == 2
+    assert nodes[4].parent == 3
+    assert nodes[1].children == [2]
+    assert nodes[2].children == [3]
+    assert nodes[3].children == [4]
+    tree = hm.visualize(nodes)
+    assert "Issue 4" in tree
+
+
+def test_auto_create_feature_for_orphan_task():
+    issues = [_make_issue(1, "task")]
+    dummy = DummyIssueManager(issues)
+    hm = HierarchyManager(dummy)
+    nodes = hm.build_tree()
+    created = hm.ensure_parents(nodes)
+    assert created
+    assert dummy.created[0][1].labels == ["feature"]
+    assert nodes[1].parent == 100
+
+
+def test_warn_on_orphans_below_threshold():
+    issues = [_make_issue(1, "task"), _make_issue(2, "task")]
+    hm = HierarchyManager(DummyIssueManager(issues), orphan_threshold=3)
+    nodes = hm.build_tree()
+    orphans = hm.warn_on_orphans(nodes)
+    assert orphans == []

--- a/tests/test_import_sorting.py
+++ b/tests/test_import_sorting.py
@@ -1,0 +1,13 @@
+import subprocess
+from pathlib import Path
+
+
+def test_isort_formatting():
+    """Ensure imports are properly sorted with isort."""
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["isort", "--check-only", str(root / "src"), str(root / "tests")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- implement `HierarchyManager` to build issue hierarchy and auto-create parent issues
- expose new hierarchy utilities from `tasks` package
- add tests for hierarchy manager
- expand tests to verify parent-child relationships and orphan handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68775055b394832dbc382733eb03f2f1