### PR TITLE
Add Slack OAuth with CLI commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,6 @@ jobs:
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_board_init_custom_path -q
           pytest -o addopts='' tests/test_github_device_flow.py -q
           pytest -o addopts='' tests/test_cli_auth.py::test_cmd_auth_login_oauth -q
+          pytest -o addopts='' tests/test_slack_oauth.py -q
+          pytest -o addopts='' tests/test_cli_slack.py::test_cmd_slack_test -q
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -22,7 +22,12 @@ from .github import (
 )
 from .github.device_flow import DeviceFlowResponse, GitHubDeviceFlow, OAuthError
 from .planning.plan_manager import PlanManager
-from .slack import get_slack_auth_info
+from .slack import (
+    SlackOAuth,
+    SlashCommandHandler,
+    get_slack_auth_info,
+    verify_slack_signature,
+)
 from .tasks.task_manager import TaskManager
 
 __version__ = "0.1.0"
@@ -56,6 +61,9 @@ __all__ = [
     # Version info
     "__version__",
     "get_slack_auth_info",
+    "SlackOAuth",
+    "SlashCommandHandler",
+    "verify_slack_signature",
 ]
 
 

--- a/src/slack/__init__.py
+++ b/src/slack/__init__.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import requests
 
+from .commands import SlashCommandHandler
+from .oauth import SlackOAuth, verify_slack_signature
+
 
 def get_slack_auth_info(token: str) -> dict:
     """Return Slack auth information for the provided token.
@@ -19,3 +22,11 @@ def get_slack_auth_info(token: str) -> dict:
     if not data.get("ok"):
         raise ValueError(f"Slack authentication failed: {data.get('error')}")
     return data
+
+
+__all__ = [
+    "get_slack_auth_info",
+    "SlackOAuth",
+    "verify_slack_signature",
+    "SlashCommandHandler",
+]

--- a/src/slack/commands.py
+++ b/src/slack/commands.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Dict
+
+
+class SlashCommandHandler:
+    """Basic slash command handler."""
+
+    def __init__(self, task_manager) -> None:
+        self.task_manager = task_manager
+
+    def handle_command(self, command: str, args: Dict) -> Dict:
+        if command == "/autonomy next":
+            return self.handle_next_command(args)
+        if command == "/autonomy update":
+            return self.handle_update_command(args)
+        if command == "/autonomy status":
+            return self.handle_status_command(args)
+        return self.handle_help_command()
+
+    def handle_next_command(self, args: Dict) -> Dict:
+        issue = self.task_manager.get_next_task()
+        if not issue:
+            return {"text": "No tasks found"}
+        return {"text": f"Next task: #{issue['number']} - {issue['title']}"}
+
+    def handle_update_command(self, args: Dict) -> Dict:
+        issue = args.get("issue")
+        status = args.get("status")
+        notes = args.get("notes")
+        if self.task_manager.update_task(issue, status=status, notes=notes):
+            return {"text": "Issue updated"}
+        return {"text": "Failed to update issue"}
+
+    def handle_status_command(self, args: Dict) -> Dict:
+        return {"text": "Status command not implemented"}
+
+    def handle_help_command(self) -> Dict:
+        return {
+            "text": (
+                "Available commands: /autonomy next, /autonomy update, /autonomy status"
+            )
+        }

--- a/src/slack/oauth.py
+++ b/src/slack/oauth.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Dict
+
+import requests
+
+
+class SlackOAuth:
+    """Simple Slack OAuth helper."""
+
+    def __init__(self, client_id: str, client_secret: str) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.base_url = "https://slack.com/api"
+
+    def get_install_url(self) -> str:
+        """Return the workspace installation URL."""
+        scopes = "channels:read,chat:write,commands,im:write,users:read,team:read"
+        return (
+            "https://slack.com/oauth/v2/authorize?"
+            f"client_id={self.client_id}&scope={scopes}"
+        )
+
+    def exchange_code(self, code: str) -> Dict:
+        """Exchange an OAuth code for an access token."""
+        response = requests.post(
+            f"{self.base_url}/oauth.v2.access",
+            data={
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "code": code,
+            },
+            timeout=10,
+        )
+        data = response.json()
+        if response.status_code != 200:
+            raise ValueError(f"Failed to exchange code: {response.status_code}")
+        if not data.get("ok"):
+            raise ValueError(data.get("error", "unknown_error"))
+        return data
+
+
+def verify_slack_signature(
+    timestamp: str, signature: str, body: bytes, signing_secret: str
+) -> bool:
+    """Verify a Slack request signature."""
+    basestring = f"v0:{timestamp}:{body.decode()}"
+    computed = hmac.new(
+        signing_secret.encode(), basestring.encode(), hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(f"v0={computed}", signature)

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -21,7 +21,7 @@ def test_cmd_auth_slack(monkeypatch, tmp_path):
         return DummyResponse(200, {"ok": True, "team": "workspace"})
 
     monkeypatch.setattr("requests.post", dummy_post)
-    args = SimpleNamespace(action="slack", token=None, slack_token=None)
+    args = SimpleNamespace(action="slack", token=None, slack_token=None, install=False)
     assert cmd_auth(vault, args) == 0
 
 

--- a/tests/test_cli_slack.py
+++ b/tests/test_cli_slack.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from src.cli.main import cmd_auth, cmd_slack
+from src.core.secret_vault import SecretVault
+
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self):
+        return self._data
+
+
+def test_cmd_auth_slack_install(monkeypatch, tmp_path, capsys):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    monkeypatch.setenv("SLACK_CLIENT_ID", "cid")
+    args = SimpleNamespace(action="slack", token=None, slack_token=None, install=True)
+    assert cmd_auth(vault, args) == 0
+    out = capsys.readouterr().out
+    assert "https://slack.com/oauth/v2/authorize" in out
+
+
+def test_cmd_auth_slack_token(tmp_path):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    args = SimpleNamespace(action="slack", token=None, slack_token="tok", install=False)
+    assert cmd_auth(vault, args) == 0
+    assert vault.get_secret("slack_token") == "tok"
+
+
+def test_cmd_slack_test(monkeypatch, tmp_path):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    vault.set_secret("slack_token", "tok")
+
+    def dummy_post(url, headers=None, timeout=10):
+        return DummyResponse({"ok": True})
+
+    monkeypatch.setattr("requests.post", dummy_post)
+    args = SimpleNamespace(slack_cmd="test", token=None)
+    assert cmd_slack(vault, args) == 0
+
+
+def test_cmd_slack_channels(monkeypatch, tmp_path, capsys):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    vault.set_secret("slack_token", "tok")
+
+    def dummy_get(url, headers=None, timeout=10):
+        return DummyResponse({"ok": True, "channels": [{"id": "C", "name": "gen"}]})
+
+    monkeypatch.setattr("requests.get", dummy_get)
+    args = SimpleNamespace(slack_cmd="channels", token=None)
+    assert cmd_slack(vault, args) == 0
+    out = capsys.readouterr().out
+    assert "gen" in out

--- a/tests/test_slack_oauth.py
+++ b/tests/test_slack_oauth.py
@@ -1,0 +1,55 @@
+import hashlib
+import hmac
+
+from src.slack.commands import SlashCommandHandler
+from src.slack.oauth import SlackOAuth, verify_slack_signature
+
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+
+    def json(self):
+        return self._data
+
+
+def test_slack_oauth_get_install_url():
+    oauth = SlackOAuth("cid", "secret")
+    url = oauth.get_install_url()
+    assert "client_id=cid" in url
+
+
+def test_slack_oauth_exchange_code(monkeypatch):
+    def dummy_post(url, data=None, timeout=10):
+        assert url == "https://slack.com/api/oauth.v2.access"
+        assert data["code"] == "abc"
+        return DummyResponse({"ok": True, "access_token": "tok"})
+
+    monkeypatch.setattr("requests.post", dummy_post)
+    oauth = SlackOAuth("cid", "secret")
+    data = oauth.exchange_code("abc")
+    assert data["access_token"] == "tok"
+
+
+def test_verify_slack_signature():
+    secret = "sec"
+    ts = "1"
+    body = b"payload"
+    sig = hmac.new(
+        secret.encode(), f"v0:{ts}:payload".encode(), hashlib.sha256
+    ).hexdigest()
+    assert verify_slack_signature(ts, f"v0={sig}", body, secret)
+
+
+def test_slash_command_handler_next():
+    class DummyTM:
+        def get_next_task(self, assignee=None, team=None):
+            return {"number": 1, "title": "task"}
+
+        def update_task(self, *a, **kw):
+            return True
+
+    handler = SlashCommandHandler(DummyTM())
+    resp = handler.handle_command("/autonomy next", {})
+    assert "Next task" in resp["text"]


### PR DESCRIPTION
## Summary
- implement SlackOAuth helper and request signature verifier
- add basic SlashCommandHandler
- extend CLI with Slack commands and Slack auth options
- update exports and CI scaffold tests
- add tests for Slack OAuth and CLI Slack commands

## Testing
- `pre-commit run --files src/slack/oauth.py src/slack/commands.py src/slack/__init__.py src/cli/main.py src/__init__.py tests/test_slack_oauth.py tests/test_cli_slack.py tests/test_cli_auth.py .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879dff71324832da41d1a9aff6d9555