### PR TITLE
Implement backlog doctor checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,5 @@ jobs:
           pytest -o addopts='' tests/test_scaffold.py -q
           pytest -o addopts='' tests/test_installation.py -q
           pytest -o addopts='' tests/test_token_storage.py -q
+          pytest -o addopts='' tests/test_backlog_doctor.py -q
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -33,6 +33,7 @@ from .slack import (
     get_slack_auth_info,
     verify_slack_signature,
 )
+from .tasks.backlog_doctor import BacklogDoctor
 from .tasks.task_manager import TaskManager
 from .verify import verify_installation
 
@@ -66,6 +67,7 @@ __all__ = [
     # Planning
     "PlanManager",
     "TaskManager",
+    "BacklogDoctor",
     "SecretVault",
     # Version info
     "__version__",

--- a/src/tasks/backlog_doctor.py
+++ b/src/tasks/backlog_doctor.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from difflib import SequenceMatcher
+from typing import Any, Dict, List, Tuple
+
+from ..github.issue_manager import IssueManager
+
+
+class BacklogDoctor:
+    """Analyze and flag backlog issues."""
+
+    STALE_LABEL = "stale"
+    DUPLICATE_LABEL = "duplicate-candidate"
+    OVERSIZED_LABEL = "oversized"
+
+    def __init__(self, issue_manager: IssueManager) -> None:
+        self.issue_manager = issue_manager
+
+    # -------------------------------------------------------------
+    def _open_issues(self) -> List[Dict[str, Any]]:
+        return self.issue_manager.list_issues(state="open")
+
+    def find_stale_issues(self, days: int = 14) -> List[Dict[str, Any]]:
+        """Return issues with no updates for the given number of days."""
+        now = datetime.now(timezone.utc)
+        stale: List[Dict[str, Any]] = []
+        for issue in self._open_issues():
+            ts = issue.get("updated_at") or issue.get("created_at")
+            if not ts:
+                continue
+            try:
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except Exception:
+                continue
+            if (now - dt).days > days:
+                stale.append(issue)
+        return stale
+
+    def find_oversized_issues(self, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return issues with more than ``limit`` checklist items."""
+        oversized: List[Dict[str, Any]] = []
+        for issue in self._open_issues():
+            body = issue.get("body", "")
+            count = sum(
+                1 for line in body.splitlines() if line.strip().startswith("- [")
+            )
+            if count > limit:
+                oversized.append(issue)
+        return oversized
+
+    def find_duplicate_candidates(
+        self, threshold: float = 0.9
+    ) -> List[Tuple[Dict[str, Any], Dict[str, Any], float]]:
+        """Return pairs of issues that look like duplicates."""
+        issues = self._open_issues()
+        dupes: List[Tuple[Dict[str, Any], Dict[str, Any], float]] = []
+        for i in range(len(issues)):
+            for j in range(i + 1, len(issues)):
+                a, b = issues[i], issues[j]
+                title_sim = SequenceMatcher(
+                    None, a.get("title", "").lower(), b.get("title", "").lower()
+                ).ratio()
+                body_sim = SequenceMatcher(
+                    None, a.get("body", "").lower(), b.get("body", "").lower()
+                ).ratio()
+                sim = max(title_sim, body_sim)
+                if sim >= threshold:
+                    dupes.append((a, b, sim))
+        return dupes
+
+    # -------------------------------------------------------------
+    def run(
+        self,
+        stale_days: int = 14,
+        checklist_limit: int = 10,
+        check_stale: bool = True,
+        check_duplicates: bool = True,
+        check_oversized: bool = True,
+    ) -> Dict[str, Any]:
+        """Run selected checks and apply labels."""
+        results = {"stale": [], "duplicates": [], "oversized": []}
+
+        if check_stale:
+            stale = self.find_stale_issues(days=stale_days)
+            results["stale"] = [i["number"] for i in stale]
+            for issue in stale:
+                self.issue_manager.update_issue_labels(
+                    issue["number"], add_labels=[self.STALE_LABEL]
+                )
+
+        if check_oversized:
+            oversized = self.find_oversized_issues(limit=checklist_limit)
+            results["oversized"] = [i["number"] for i in oversized]
+            for issue in oversized:
+                self.issue_manager.update_issue_labels(
+                    issue["number"], add_labels=[self.OVERSIZED_LABEL]
+                )
+
+        if check_duplicates:
+            duplicates = self.find_duplicate_candidates()
+            results["duplicates"] = [
+                (a["number"], b["number"]) for a, b, _ in duplicates
+            ]
+            for a, b, _ in duplicates:
+                self.issue_manager.update_issue_labels(
+                    a["number"], add_labels=[self.DUPLICATE_LABEL]
+                )
+                self.issue_manager.update_issue_labels(
+                    b["number"], add_labels=[self.DUPLICATE_LABEL]
+                )
+
+        return results

--- a/tests/test_backlog_doctor.py
+++ b/tests/test_backlog_doctor.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timedelta, timezone
+
+from src.tasks.backlog_doctor import BacklogDoctor
+
+
+class DummyIssueManager:
+    def __init__(self, issues):
+        self._issues = issues
+        self.labeled = []
+
+    def list_issues(self, state="open"):
+        return self._issues
+
+    def update_issue_labels(self, issue_number, add_labels=None, remove_labels=None):
+        self.labeled.append((issue_number, add_labels, remove_labels))
+        return True
+
+
+def _make_issue(num, title="Issue", days=0, body=""):
+    ts = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    return {"number": num, "title": title, "updated_at": ts, "body": body}
+
+
+def test_find_stale_issues():
+    issues = [_make_issue(1, days=15), _make_issue(2, days=5)]
+    doctor = BacklogDoctor(DummyIssueManager(issues))
+    stale = doctor.find_stale_issues(days=14)
+    assert [i["number"] for i in stale] == [1]
+
+
+def test_find_oversized_issues():
+    body = "\n".join(["- [ ] item" for _ in range(11)])
+    issues = [_make_issue(1, body=body), _make_issue(2, body="- [ ] one")]
+    doctor = BacklogDoctor(DummyIssueManager(issues))
+    over = doctor.find_oversized_issues(limit=10)
+    assert [i["number"] for i in over] == [1]
+
+
+def test_find_duplicate_candidates():
+    issues = [
+        _make_issue(1, title="Add login"),
+        _make_issue(2, title="Add login page"),
+        _make_issue(3, title="Different"),
+    ]
+    doctor = BacklogDoctor(DummyIssueManager(issues))
+    dupes = doctor.find_duplicate_candidates(threshold=0.8)
+    pairs = {(a["number"], b["number"]) for a, b, _ in dupes}
+    assert (1, 2) in pairs
+
+
+def test_run_applies_labels():
+    body = "\n".join(["- [ ] item" for _ in range(12)])
+    issues = [_make_issue(1, days=20, body=body)]
+    mgr = DummyIssueManager(issues)
+    doctor = BacklogDoctor(mgr)
+    result = doctor.run()
+    assert result["stale"] == [1]
+    assert result["oversized"] == [1]
+    assert mgr.labeled  # labels applied

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from src.cli.main import (
     cmd_board_init,
+    cmd_doctor,
     cmd_init,
     cmd_list,
     cmd_next,
@@ -209,3 +210,26 @@ def test_cmd_board_init_custom_path(monkeypatch, tmp_path: Path):
     assert cmd_board_init(manager, args) == 0
     assert Path(captured["path"]) == custom
     assert custom.exists()
+
+
+def test_cmd_doctor_run(monkeypatch, tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    manager.issue_manager = object()
+
+    class DummyDoctor:
+        def __init__(self, mgr):
+            pass
+
+        def run(self, **kwargs):
+            return {"stale": [1], "duplicates": [], "oversized": []}
+
+    monkeypatch.setattr("src.tasks.backlog_doctor.BacklogDoctor", DummyDoctor)
+    args = SimpleNamespace(
+        doctor_cmd="run",
+        stale_days=14,
+        checklist_limit=10,
+        stale=False,
+        duplicates=False,
+        oversized=False,
+    )
+    assert cmd_doctor(manager, args) == 0


### PR DESCRIPTION
## Summary
- add BacklogDoctor helper to flag stale, duplicate or oversized issues
- expose BacklogDoctor in package exports
- extend CLI with `doctor` command
- create tests for BacklogDoctor and CLI doctor command
- run new tests in CI

## Testing
- `pip install -e .[dev]`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a14725cb4832dbc9a23b067fbe1ab