### PR TITLE
Implement audit logging with git-backed history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,6 @@ jobs:
           pytest -o addopts='' tests/test_installation.py -q
           pytest -o addopts='' tests/test_token_storage.py -q
           pytest -o addopts='' tests/test_backlog_doctor.py -q
+          pytest -o addopts='' tests/test_audit.py -q
+          pytest -o addopts='' tests/test_cli_commands.py::test_cmd_audit_and_undo -q
 

--- a/src/audit/logger.py
+++ b/src/audit/logger.py
@@ -1,0 +1,109 @@
+import json
+from datetime import datetime
+from hashlib import sha1
+from pathlib import Path
+from typing import Any, Dict
+
+
+class AuditLogger:
+    """Simple append-only JSON lines audit logger.
+
+    Parameters
+    ----------
+    log_path:
+        Path to the audit log file.
+    use_git:
+        If ``True`` the logger will commit updates to ``log_path`` using Git.
+    """
+
+    def __init__(self, log_path: Path, use_git: bool = False) -> None:
+        self.log_path = Path(log_path)
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.log_path.exists():
+            self.log_path.touch()
+        self.use_git = use_git
+        self.repo_path = self.log_path.parent
+        if self.use_git:
+            self._ensure_repo()
+
+    def log(self, operation: str, details: Dict[str, Any]) -> str:
+        """Log an operation and return its unique hash."""
+        payload = {
+            "operation": operation,
+            "details": details,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        digest = sha1(json.dumps(payload, sort_keys=True).encode()).hexdigest()[:8]
+        payload["hash"] = digest
+        with self.log_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(payload) + "\n")
+        if self.use_git:
+            message = f"audit: {payload['hash']} {operation}"
+            self._git_commit(message)
+        return digest
+
+    def iter_logs(self):
+        """Yield log entries as dictionaries."""
+        if not self.log_path.exists():
+            return
+        with self.log_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_repo(self) -> None:
+        """Ensure ``repo_path`` is a git repository with basic config."""
+        import subprocess
+
+        if (
+            subprocess.run(
+                ["git", "-C", str(self.repo_path), "rev-parse"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode
+            != 0
+        ):
+            subprocess.run(["git", "-C", str(self.repo_path), "init"], check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(self.repo_path),
+                    "config",
+                    "user.email",
+                    "audit@example.com",
+                ],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(self.repo_path),
+                    "config",
+                    "user.name",
+                    "Autonomy Audit",
+                ],
+                check=True,
+            )
+
+    def _git_commit(self, message: str) -> None:
+        """Commit the audit log file with ``message``."""
+        import subprocess
+
+        subprocess.run(
+            ["git", "-C", str(self.repo_path), "add", str(self.log_path.name)],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.repo_path), "commit", "-m", message],
+            check=True,
+        )

--- a/src/audit/undo.py
+++ b/src/audit/undo.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .logger import AuditLogger
+
+
+class UndoManager:
+    """Undo operations previously logged by :class:`AuditLogger`."""
+
+    def __init__(self, issue_manager: Any, logger: AuditLogger) -> None:
+        self.issue_manager = issue_manager
+        self.logger = logger
+
+    def _load_logs(self) -> list[Dict[str, Any]]:
+        return list(self.logger.iter_logs())
+
+    def undo(self, hash_value: str) -> bool:
+        """Undo a specific operation by its hash."""
+        logs = self._load_logs()
+        for entry in reversed(logs):
+            if entry.get("hash") == hash_value:
+                return self._apply(entry)
+        return False
+
+    def undo_last(self) -> Optional[str]:
+        logs = self._load_logs()
+        if not logs:
+            return None
+        last = logs[-1]
+        if self._apply(last):
+            return last.get("hash")
+        return None
+
+    def _apply(self, entry: Dict[str, Any]) -> bool:
+        op = entry.get("operation")
+        details = entry.get("details", {})
+        if op == "update_labels":
+            issue = details.get("issue")
+            add = details.get("add_labels") or []
+            remove = details.get("remove_labels") or []
+            return self.issue_manager.update_issue_labels(
+                issue, add_labels=remove, remove_labels=add
+            )
+        elif op == "update_state":
+            issue = details.get("issue")
+            prev = details.get("previous")
+            if prev:
+                return self.issue_manager.update_issue_state(issue, prev)
+        elif op == "add_comment":
+            issue = details.get("issue")
+            comment = details.get("comment")
+            if comment:
+                # Cannot truly undo a comment via GitHub API; post a note instead
+                note = f"Undo: delete previous comment -> {comment}"
+                return self.issue_manager.add_comment(issue, note)
+        return False

--- a/src/core/workflow_manager.py
+++ b/src/core/workflow_manager.py
@@ -63,9 +63,14 @@ class WorkflowManager:
         self.config = config or WorkflowConfig()
 
         # Initialize components
+        from ..audit.logger import AuditLogger
         from ..github.issue_manager import IssueManager
 
-        self.issue_manager = IssueManager(github_token, owner, repo)
+        log_path = self.workspace_path / "audit.log"
+        self.audit_logger = AuditLogger(log_path, use_git=True)
+        self.issue_manager = IssueManager(
+            github_token, owner, repo, audit_logger=self.audit_logger
+        )
         self.pm_agent = PMAgent(self.config)
         self.sde_agent = SDEAgent(self.config)
         self.qa_agent = QAAgent(self.config)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from src.audit.logger import AuditLogger
+from src.audit.undo import UndoManager
+
+
+class DummyIM:
+    def __init__(self):
+        self.labels = None
+
+    def update_issue_labels(self, issue_number, add_labels=None, remove_labels=None):
+        self.labels = (issue_number, add_labels, remove_labels)
+        return True
+
+
+def test_logger_and_undo(tmp_path: Path) -> None:
+    logger = AuditLogger(tmp_path / "audit.log", use_git=True)
+    # ensure git repo exists
+    assert (tmp_path / ".git").exists()
+    dummy = DummyIM()
+    h = logger.log(
+        "update_labels", {"issue": 2, "add_labels": ["a"], "remove_labels": None}
+    )
+    undo = UndoManager(dummy, logger)
+    assert undo.undo_last() == h
+    assert dummy.labels == (2, [], ["a"])
+    # verify commit message contains hash
+    import subprocess
+
+    log = subprocess.check_output(
+        ["git", "-C", str(tmp_path), "log", "-1", "--pretty=%s"],
+        text=True,
+    ).strip()
+    assert h in log


### PR DESCRIPTION
## Summary
- extend AuditLogger with optional git integration
- commit audit log updates to a git repo when enabled
- use git-backed AuditLogger from WorkflowManager and tests
- verify commits in new/updated tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1a759d20832d8f792c6bb2507aaf