### PR TITLE
Implement FastAPI API and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,5 @@ jobs:
           pytest -o addopts='' tests/test_backlog_doctor.py -q
           pytest -o addopts='' tests/test_audit.py -q
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_audit_and_undo -q
+          pytest -o addopts='' tests/test_api_server.py -q
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,6 +8,7 @@ Inspired by "Writing Software in English" by Mehul Bhardwaj.
 https://mehulbhardwaj.substack.com/p/building-software-in-english
 """
 
+from .api import create_app
 from .core.agents import BaseAgent, PMAgent, QAAgent, SDEAgent
 from .core.config import WorkflowConfig
 from .core.secret_vault import SecretVault
@@ -76,6 +77,7 @@ __all__ = [
     "SlashCommandHandler",
     "verify_slack_signature",
     "verify_installation",
+    "create_app",
 ]
 
 

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,3 @@
+from .server import create_app
+
+__all__ = ["create_app"]

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from ..audit.logger import AuditLogger
+from ..audit.undo import UndoManager
+from ..github.issue_manager import IssueManager
+from ..tasks.backlog_doctor import BacklogDoctor
+from ..tasks.hierarchy_manager import HierarchyManager
+from ..tasks.task_manager import TaskManager
+
+
+class UpdateTaskRequest(BaseModel):
+    status: Optional[str] = None
+    done: bool = False
+    notes: Optional[str] = None
+
+
+def create_app(
+    issue_manager: IssueManager,
+    audit_logger: Optional[AuditLogger] = None,
+) -> FastAPI:
+    """Return a FastAPI app wired with core managers."""
+
+    task_manager = TaskManager.__new__(TaskManager)
+    task_manager.issue_manager = issue_manager
+    hierarchy_manager = HierarchyManager(issue_manager)
+    backlog_doctor = BacklogDoctor(issue_manager)
+    audit_logger = audit_logger or AuditLogger(Path("audit.log"))
+    undo_manager = UndoManager(issue_manager, audit_logger)
+
+    app = FastAPI(title="Autonomy API", version="1.0")
+
+    # ------------------------------ Tasks ------------------------------
+    @app.get("/api/v1/tasks/next")
+    def get_next_task(assignee: Optional[str] = None, team: Optional[str] = None):
+        issue = task_manager.get_next_task(assignee=assignee, team=team)
+        if not issue:
+            raise HTTPException(status_code=404, detail="No tasks found")
+        return issue
+
+    @app.get("/api/v1/tasks")
+    def list_tasks(
+        assignee: Optional[str] = None,
+        team: Optional[str] = None,
+        limit: int = 10,
+    ):
+        return task_manager.list_tasks(assignee=assignee, team=team, limit=limit)
+
+    @app.post("/api/v1/tasks/{issue_id}/update")
+    def update_task(issue_id: int, payload: UpdateTaskRequest):
+        success = task_manager.update_task(
+            issue_id,
+            status=payload.status,
+            done=payload.done,
+            notes=payload.notes,
+        )
+        if not success:
+            raise HTTPException(status_code=500, detail="Failed to update task")
+        return {"success": True}
+
+    # --------------------------- Backlog Doctor ---------------------------
+    @app.post("/api/v1/backlog/doctor/run")
+    def run_backlog_doctor(
+        stale_days: int = 14,
+        checklist_limit: int = 10,
+    ):
+        return backlog_doctor.run(
+            stale_days=stale_days,
+            checklist_limit=checklist_limit,
+        )
+
+    # ------------------------------ Audit ------------------------------
+    @app.get("/api/v1/audit/log")
+    def get_audit_log():
+        return list(audit_logger.iter_logs())
+
+    @app.post("/api/v1/audit/undo/{hash_value}")
+    def undo(hash_value: str):
+        if undo_manager.undo(hash_value):
+            return {"success": True}
+        raise HTTPException(status_code=404, detail="Operation not found")
+
+    return app

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from src.api import create_app
+from src.audit.logger import AuditLogger
+
+
+class DummyIssueManager:
+    def __init__(self, issues):
+        self._issues = issues
+        self.updated = None
+        self.state_update = None
+        self.comment = None
+
+    def list_issues(self, state="open"):
+        return self._issues
+
+    def update_issue_labels(self, issue_number, add_labels=None, remove_labels=None):
+        self.updated = (issue_number, add_labels, remove_labels)
+        return True
+
+    def update_issue_state(self, issue_number, state):
+        self.state_update = (issue_number, state)
+        return True
+
+    def add_comment(self, issue_number, comment):
+        self.comment = (issue_number, comment)
+        return True
+
+
+def _make_issue(num, prio, days=0):
+    return {
+        "number": num,
+        "title": f"Issue {num}",
+        "labels": [{"name": prio}],
+        "created_at": (datetime.now(timezone.utc) - timedelta(days=days)).isoformat(),
+    }
+
+
+def test_tasks_endpoints():
+    issues = [_make_issue(1, "priority-low", 5), _make_issue(2, "priority-high", 1)]
+    dummy = DummyIssueManager(issues)
+    app = create_app(dummy, audit_logger=AuditLogger(Path("test_audit.log")))
+    client = TestClient(app)
+
+    resp = client.get("/api/v1/tasks/next")
+    assert resp.status_code == 200
+    assert resp.json()["number"] == 2
+
+    resp = client.post(
+        f"/api/v1/tasks/1/update",
+        json={"status": "in-progress", "done": True, "notes": "x"},
+    )
+    assert resp.status_code == 200
+    assert dummy.updated == (1, ["in-progress"], None)
+    assert dummy.state_update == (1, "closed")
+    assert dummy.comment == (1, "x")
+
+
+def test_backlog_doctor_endpoint(tmp_path):
+    body = "\n".join(["- [ ] item" for _ in range(12)])
+    issues = [
+        {
+            "number": 1,
+            "title": "T",
+            "updated_at": (datetime.now(timezone.utc) - timedelta(days=20)).isoformat(),
+            "body": body,
+        },
+    ]
+    dummy = DummyIssueManager(issues)
+    app = create_app(dummy, audit_logger=AuditLogger(tmp_path / "log.txt"))
+    client = TestClient(app)
+
+    resp = client.post("/api/v1/backlog/doctor/run")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["stale"] == [1]
+    assert data["oversized"] == [1]


### PR DESCRIPTION
## Summary
- introduce `api` module with FastAPI app creator
- export `create_app` from package
- add tests for new API server
- run API tests in CI workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a60ebd1c8832da1fb5a9c11a61ef4