### PR TITLE
Implement basic Slack integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           pytest -o addopts='' tests/test_cli_auth.py::test_cmd_auth_login_oauth -q
           pytest -o addopts='' tests/test_slack_oauth.py -q
           pytest -o addopts='' tests/test_cli_slack.py::test_cmd_slack_test -q
+          pytest -o addopts='' tests/test_cli_slack.py::test_cmd_slack_notify -q
+          pytest -o addopts='' tests/test_slack_bot.py -q
           pytest -o addopts='' tests/test_scaffold.py -q
           pytest -o addopts='' tests/test_installation.py -q
           pytest -o addopts='' tests/test_token_storage.py -q

--- a/docs/ISSUE_NOTES.md
+++ b/docs/ISSUE_NOTES.md
@@ -10,3 +10,6 @@ Both features have been tested and integrated into the CLI, so Issues #1 and #2 
 
 ## Closed Issue #3
 CLI now includes Slack authentication and extended auth commands (login, logout, status, github, slack). Associated tests verify new functionality.
+
+## Closed Issue #9
+Initial Slack integration is implemented with a `SlackBot` helper and CLI `notify` command. Tests cover message posting and the new CLI workflow.

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -161,6 +161,9 @@ Environment Variables:
     slack_sub = slack_parser.add_subparsers(dest="slack_cmd")
     slack_sub.add_parser("test", help="Test Slack authentication")
     slack_sub.add_parser("channels", help="List Slack channels")
+    notify_parser = slack_sub.add_parser("notify", help="Send Slack notification")
+    notify_parser.add_argument("channel", help="Channel ID")
+    notify_parser.add_argument("message", help="Message text")
 
     # Auth command
     auth_parser = subparsers.add_parser("auth", help="Manage authentication")
@@ -659,6 +662,16 @@ def cmd_slack(vault: SecretVault, args) -> int:
         for ch in data.get("channels", []):
             print(f"{ch['id']}: {ch['name']}")
         return 0
+
+    if args.slack_cmd == "notify":
+        from ..slack import SlackBot
+
+        bot = SlackBot(token)
+        if bot.post_message(args.channel, args.message):
+            print("\N{CHECK MARK} Notification sent")
+            return 0
+        print("Error: failed to send notification")
+        return 1
 
     print(f"Unknown Slack command: {args.slack_cmd}")
     return 1

--- a/src/slack/__init__.py
+++ b/src/slack/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import requests
 
+from .bot import SlackBot
 from .commands import SlashCommandHandler
 from .oauth import SlackOAuth, verify_slack_signature
 
@@ -29,4 +30,5 @@ __all__ = [
     "SlackOAuth",
     "verify_slack_signature",
     "SlashCommandHandler",
+    "SlackBot",
 ]

--- a/src/slack/bot.py
+++ b/src/slack/bot.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+class SlackBot:
+    """Minimal Slack Web API wrapper for posting messages."""
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+        self.base_url = "https://slack.com/api"
+
+    def post_message(
+        self, channel: str, text: str, blocks: Optional[List[Dict[str, Any]]] = None
+    ) -> bool:
+        """Post a message to Slack and return success status."""
+        payload: Dict[str, Any] = {"channel": channel, "text": text}
+        if blocks is not None:
+            payload["blocks"] = blocks
+        response = requests.post(
+            f"{self.base_url}/chat.postMessage",
+            json=payload,
+            headers={"Authorization": f"Bearer {self.token}"},
+            timeout=10,
+        )
+        data = response.json()
+        return response.status_code == 200 and data.get("ok", False)

--- a/tests/test_cli_slack.py
+++ b/tests/test_cli_slack.py
@@ -54,3 +54,15 @@ def test_cmd_slack_channels(monkeypatch, tmp_path, capsys):
     assert cmd_slack(vault, args) == 0
     out = capsys.readouterr().out
     assert "gen" in out
+
+
+def test_cmd_slack_notify(monkeypatch, tmp_path):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    vault.set_secret("slack_token", "tok")
+
+    def dummy_post(url, json=None, headers=None, timeout=10):
+        return DummyResponse({"ok": True})
+
+    monkeypatch.setattr("requests.post", dummy_post)
+    args = SimpleNamespace(slack_cmd="notify", token=None, channel="C", message="hello")
+    assert cmd_slack(vault, args) == 0

--- a/tests/test_slack_bot.py
+++ b/tests/test_slack_bot.py
@@ -1,0 +1,31 @@
+from src.slack.bot import SlackBot
+
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+
+    def json(self):
+        return self._data
+
+
+def test_post_message_success(monkeypatch):
+    def dummy_post(url, json=None, headers=None, timeout=10):
+        assert url.endswith("/chat.postMessage")
+        assert json["channel"] == "C"
+        assert json["text"] == "hi"
+        return DummyResponse({"ok": True})
+
+    monkeypatch.setattr("requests.post", dummy_post)
+    bot = SlackBot("tok")
+    assert bot.post_message("C", "hi")
+
+
+def test_post_message_failure(monkeypatch):
+    def dummy_post(url, json=None, headers=None, timeout=10):
+        return DummyResponse({"ok": False}, status_code=400)
+
+    monkeypatch.setattr("requests.post", dummy_post)
+    bot = SlackBot("tok")
+    assert not bot.post_message("C", "hi")


### PR DESCRIPTION
## Summary
- add `SlackBot` helper class
- export `SlackBot` via `src.slack`
- support `slack notify` CLI command
- add tests for Slack bot and notify command
- include new tests in CI
- document completion of Issue #9

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6bb26804832d9e46a101e41c72fb