### PR TITLE
Add manual pin/unpin system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,5 +81,7 @@ jobs:
           pytest -o addopts='' tests/test_backlog_doctor.py -q
           pytest -o addopts='' tests/test_audit.py -q
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_audit_and_undo -q
+          pytest -o addopts='' tests/test_pinned_items.py -q
+          pytest -o addopts='' tests/test_cli_commands.py::test_cmd_pin_unpin_and_list -q
           pytest -o addopts='' tests/test_api_server.py -q
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -27,6 +27,10 @@ def create_app(
 
     task_manager = TaskManager.__new__(TaskManager)
     task_manager.issue_manager = issue_manager
+    from ..tasks.pinned_items import PinnedItemsStore
+
+    task_manager.pinned_store = PinnedItemsStore()
+    task_manager.project_id = f"{issue_manager.owner}/{issue_manager.repo}"
     backlog_doctor = BacklogDoctor(issue_manager)
     audit_logger = audit_logger or AuditLogger(Path("audit.log"))
     undo_manager = UndoManager(issue_manager, audit_logger)

--- a/src/tasks/pinned_items.py
+++ b/src/tasks/pinned_items.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+class PinnedItemsStore:
+    """Simple file-based store for pinned items."""
+
+    def __init__(self, config_dir: Path | None = None) -> None:
+        self.config_dir = config_dir or Path.home() / ".autonomy"
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.pinned_file = self.config_dir / "pinned_items.json"
+
+    def load_pinned_items(self) -> Dict[str, List[str]]:
+        if self.pinned_file.exists():
+            with open(self.pinned_file, "r", encoding="utf-8") as f:
+                try:
+                    return json.load(f)
+                except Exception:
+                    return {}
+        return {}
+
+    def save_pinned_items(self, data: Dict[str, List[str]]) -> None:
+        with open(self.pinned_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def pin_item(self, project_id: str, item_id: str) -> None:
+        data = self.load_pinned_items()
+        if project_id not in data:
+            data[project_id] = []
+        if item_id not in data[project_id]:
+            data[project_id].append(item_id)
+        self.save_pinned_items(data)
+
+    def unpin_item(self, project_id: str, item_id: str) -> None:
+        data = self.load_pinned_items()
+        if project_id in data and item_id in data[project_id]:
+            data[project_id].remove(item_id)
+            if not data[project_id]:
+                del data[project_id]
+        self.save_pinned_items(data)
+
+    def is_pinned(self, project_id: str, item_id: str) -> bool:
+        data = self.load_pinned_items()
+        return item_id in data.get(project_id, [])
+
+    def list_pinned(self, project_id: str) -> List[str]:
+        data = self.load_pinned_items()
+        return data.get(project_id, [])

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -13,6 +13,8 @@ class DummyIssueManager:
         self.updated = None
         self.state_update = None
         self.comment = None
+        self.owner = "o"
+        self.repo = "r"
 
     def list_issues(self, state="open"):
         return self._issues

--- a/tests/test_pinned_items.py
+++ b/tests/test_pinned_items.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from src.tasks.pinned_items import PinnedItemsStore
+
+
+def test_pin_unpin(tmp_path: Path):
+    store = PinnedItemsStore(config_dir=tmp_path)
+    store.pin_item("proj", "1")
+    assert store.is_pinned("proj", "1")
+    store.unpin_item("proj", "1")
+    assert not store.is_pinned("proj", "1")
+
+
+def test_persistence(tmp_path: Path):
+    store = PinnedItemsStore(config_dir=tmp_path)
+    store.pin_item("proj", "1")
+    new_store = PinnedItemsStore(config_dir=tmp_path)
+    assert new_store.is_pinned("proj", "1")


### PR DESCRIPTION
## Summary
- support pinned issues via JSON-based `PinnedItemsStore`
- handle pinned tasks in `TaskManager`
- expose `pin`/`unpin` and `list --pinned` CLI commands
- wire up API server with pinned store
- test pinning behavior and CLI options
- run new tests in CI workflow

## Testing
- `pre-commit run --files src/tasks/pinned_items.py src/tasks/task_manager.py src/cli/main.py tests/test_pinned_items.py tests/test_task_manager.py tests/test_cli_commands.py src/api/server.py tests/test_api_server.py .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b2b41653c832d964192e91b4292f2