### PR TITLE
Implement multi-signal ranking engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,4 +84,5 @@ jobs:
           pytest -o addopts='' tests/test_pinned_items.py -q
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_pin_unpin_and_list -q
           pytest -o addopts='' tests/test_api_server.py -q
+          pytest -o addopts='' tests/test_ranking_engine.py -q
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -30,6 +30,9 @@ def create_app(
     from ..tasks.pinned_items import PinnedItemsStore
 
     task_manager.pinned_store = PinnedItemsStore()
+    from ..tasks.ranking import RankingEngine
+
+    task_manager.ranking = RankingEngine()
     task_manager.project_id = f"{issue_manager.owner}/{issue_manager.repo}"
     backlog_doctor = BacklogDoctor(issue_manager)
     audit_logger = audit_logger or AuditLogger(Path("audit.log"))

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -1,4 +1,11 @@
 from .hierarchy_manager import HierarchyManager, IssueNode
+from .ranking import RankingConfig, RankingEngine
 from .task_manager import TaskManager
 
-__all__ = ["TaskManager", "HierarchyManager", "IssueNode"]
+__all__ = [
+    "TaskManager",
+    "HierarchyManager",
+    "IssueNode",
+    "RankingConfig",
+    "RankingEngine",
+]

--- a/src/tasks/ranking.py
+++ b/src/tasks/ranking.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - yaml optional
+    yaml = None
+
+
+@dataclass
+class RankingConfig:
+    """Configuration for task ranking."""
+
+    weights: Dict[str, float] = field(
+        default_factory=lambda: {
+            "priority_field": 100.0,
+            "sprint_proximity": 3.0,
+            "issue_age": 1.0,
+            "pinned_boost": 1000.0,
+        }
+    )
+    priority_mapping: Dict[str, int] = field(
+        default_factory=lambda: {
+            "priority-critical": 4,
+            "priority-high": 3,
+            "priority-medium": 2,
+            "priority-low": 1,
+        }
+    )
+    excluded_labels: List[str] = field(default_factory=lambda: ["blocked"])
+
+    def load_from_file(self, path: Path) -> None:
+        """Update configuration from YAML file if present."""
+        if not path.exists() or yaml is None:
+            return
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except Exception:
+            return
+        self.weights.update(data.get("weights", {}))
+        self.priority_mapping.update(data.get("priority_mapping", {}))
+        if "excluded_labels" in data:
+            self.excluded_labels = list(data["excluded_labels"])
+
+
+class RankingEngine:
+    """Multi-signal ranking engine for issues."""
+
+    def __init__(self, config: Optional[RankingConfig] = None) -> None:
+        self.config = config or RankingConfig()
+
+    # ------------------------------------------------------------------
+    def score_issue(
+        self, issue: Dict[str, Any], *, pinned: bool = False, explain: bool = False
+    ) -> float | tuple[float, Dict[str, Any]]:
+        labels = [
+            lab["name"] if isinstance(lab, dict) and "name" in lab else lab
+            for lab in issue.get("labels", [])
+        ]
+        if (
+            any(lbl in self.config.excluded_labels for lbl in labels)
+            or issue.get("state") == "closed"
+        ):
+            return (float("-inf"), {}) if explain else float("-inf")
+
+        w = self.config.weights
+        priority = 0
+        for lbl in labels:
+            priority = max(priority, self.config.priority_mapping.get(lbl, 0))
+
+        sprint_score = 0
+        milestone = issue.get("milestone")
+        if isinstance(milestone, dict) and milestone.get("due_on"):
+            try:
+                due = datetime.fromisoformat(milestone["due_on"].replace("Z", "+00:00"))
+                days = (due - datetime.now(timezone.utc)).days
+                sprint_score = max(0, 30 - days)
+            except Exception:
+                pass
+
+        age_days = 0
+        created = issue.get("created_at")
+        if created:
+            try:
+                dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+                age_days = (datetime.now(timezone.utc) - dt).days
+            except Exception:
+                pass
+
+        score = 0.0
+        score += priority * w.get("priority_field", 100)
+        score += sprint_score * w.get("sprint_proximity", 3)
+        score -= age_days * w.get("issue_age", 1)
+        if pinned:
+            score += w.get("pinned_boost", 1000)
+
+        if explain:
+            return (
+                score,
+                {
+                    "priority": priority,
+                    "sprint_proximity": sprint_score,
+                    "age_penalty": age_days,
+                    "pinned": pinned,
+                },
+            )
+        return score

--- a/src/tasks/task_manager.py
+++ b/src/tasks/task_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from ..github.issue_manager import IssueManager

--- a/src/tasks/task_manager.py
+++ b/src/tasks/task_manager.py
@@ -5,13 +5,7 @@ from typing import Any, Dict, Optional
 
 from ..github.issue_manager import IssueManager
 from .pinned_items import PinnedItemsStore
-
-PRIORITY_WEIGHTS = {
-    "priority-critical": 4,
-    "priority-high": 3,
-    "priority-medium": 2,
-    "priority-low": 1,
-}
+from .ranking import RankingConfig, RankingEngine
 
 
 class TaskManager:
@@ -23,40 +17,21 @@ class TaskManager:
         owner: str,
         repo: str,
         pinned_store: PinnedItemsStore | None = None,
+        ranking_config: RankingConfig | None = None,
     ) -> None:
         self.issue_manager = IssueManager(github_token, owner, repo)
         self.pinned_store = pinned_store or PinnedItemsStore()
         self.project_id = f"{owner}/{repo}"
+        self.ranking = RankingEngine(ranking_config)
 
     # -------------------------- retrieval helpers ---------------------------
     def _score_issue(
         self, issue: Dict[str, Any], explain: bool = False
     ) -> float | tuple[float, dict]:
-        labels = [
-            label["name"] if isinstance(label, dict) and "name" in label else label
-            for label in issue.get("labels", [])
-        ]
-        if self.pinned_store.is_pinned(self.project_id, str(issue.get("number"))):
+        pinned = self.pinned_store.is_pinned(self.project_id, str(issue.get("number")))
+        if pinned:
             return (float("-inf"), {}) if explain else float("-inf")
-        if "blocked" in labels or issue.get("state") == "closed":
-            return (float("-inf"), {}) if explain else float("-inf")
-
-        priority = 0
-        for label in labels:
-            priority = max(priority, PRIORITY_WEIGHTS.get(label, 0))
-
-        created = issue.get("created_at")
-        age_days = 0
-        if created:
-            try:
-                dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
-                age_days = (datetime.now(timezone.utc) - dt).days
-            except Exception:
-                pass
-        score = priority * 100 - age_days
-        if explain:
-            return score, {"priority": priority, "age_penalty": age_days}
-        return score
+        return self.ranking.score_issue(issue, pinned=False, explain=explain)
 
     def get_next_task(
         self,

--- a/tests/test_ranking_engine.py
+++ b/tests/test_ranking_engine.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta, timezone
+
+from src.tasks.ranking import RankingConfig, RankingEngine
+
+
+def _make_issue(num: int, prio: str, days: int = 0):
+    return {
+        "number": num,
+        "title": f"Issue {num}",
+        "labels": [{"name": prio}],
+        "created_at": (datetime.now(timezone.utc) - timedelta(days=days)).isoformat(),
+    }
+
+
+def test_score_ordering():
+    eng = RankingEngine()
+    high = _make_issue(1, "priority-high", 1)
+    low = _make_issue(2, "priority-low", 0)
+    assert eng.score_issue(high) > eng.score_issue(low)
+
+
+def test_explain_score():
+    eng = RankingEngine()
+    issue = _make_issue(3, "priority-high", 0)
+    score, breakdown = eng.score_issue(issue, explain=True)
+    assert score == eng.score_issue(issue)
+    assert breakdown["priority"] == 3
+    assert "age_penalty" in breakdown
+
+
+def test_custom_weights():
+    cfg = RankingConfig(weights={"priority_field": 1, "issue_age": 10})
+    eng = RankingEngine(cfg)
+    newer = _make_issue(4, "priority-low", 0)
+    older = _make_issue(5, "priority-low", 5)
+    assert eng.score_issue(newer) > eng.score_issue(older)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -43,6 +43,9 @@ def test_get_next_task(monkeypatch, tmp_path):
     tm.issue_manager = dummy
     tm.pinned_store = PinnedItemsStore(config_dir=tmp_path)
     tm.project_id = "o/r"
+    from src.tasks.ranking import RankingEngine
+
+    tm.ranking = RankingEngine()
     issue = tm.get_next_task()
     assert issue["number"] == 2
 
@@ -54,15 +57,22 @@ def test_get_next_task_explain(monkeypatch, tmp_path):
     tm.issue_manager = dummy
     tm.pinned_store = PinnedItemsStore(config_dir=tmp_path)
     tm.project_id = "o/r"
+    from src.tasks.ranking import RankingEngine
+
+    tm.ranking = RankingEngine()
     issue, breakdown = tm.get_next_task(explain=True)
     assert issue["number"] == 1
     assert breakdown["priority"] == 1
+    assert "age_penalty" in breakdown
 
 
 def test_update_task(monkeypatch):
     dummy = DummyIssueManager([])
     tm = TaskManager.__new__(TaskManager)
     tm.issue_manager = dummy
+    from src.tasks.ranking import RankingEngine
+
+    tm.ranking = RankingEngine()
     assert tm.update_task(3, status="in-progress", done=True, notes="done")
     assert dummy.updated == (3, ["in-progress"], None)
     assert dummy.state_update == (3, "closed")
@@ -79,6 +89,9 @@ def test_get_next_task_none(monkeypatch, tmp_path):
     tm.issue_manager = dummy
     tm.pinned_store = PinnedItemsStore(config_dir=tmp_path)
     tm.project_id = "o/r"
+    from src.tasks.ranking import RankingEngine
+
+    tm.ranking = RankingEngine()
     assert tm.get_next_task() is None
 
 
@@ -92,6 +105,9 @@ def test_list_tasks(monkeypatch, tmp_path):
     tm.issue_manager = dummy
     tm.pinned_store = PinnedItemsStore(config_dir=tmp_path)
     tm.project_id = "o/r"
+    from src.tasks.ranking import RankingEngine
+
+    tm.ranking = RankingEngine()
     tasks = tm.list_tasks()
     assert [t["number"] for t in tasks] == [2, 1]
 
@@ -100,6 +116,9 @@ def test_update_task_rollover(monkeypatch):
     dummy = DummyIssueManager([])
     tm = TaskManager.__new__(TaskManager)
     tm.issue_manager = dummy
+    from src.tasks.ranking import RankingEngine
+
+    tm.ranking = RankingEngine()
     called = {}
 
     def roll(num):
@@ -120,4 +139,7 @@ def test_pinned_items_skipped(tmp_path):
     tm.issue_manager = dummy
     tm.pinned_store = store
     tm.project_id = "o/r"
+    from src.tasks.ranking import RankingEngine
+
+    tm.ranking = RankingEngine()
     assert tm.get_next_task() is None


### PR DESCRIPTION
## Summary
- add configurable `RankingEngine` with YAML-configurable weights
- integrate ranking engine into `TaskManager`
- update API server to initialize ranking engine
- add unit tests for ranking engine and update TaskManager tests
- run new test in CI scaffold job

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b348d5d50832db3c1bb34a1d6c04a