### PR TITLE
Implement Slack slash commands integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           pytest -o addopts='' tests/test_cli_slack.py::test_cmd_slack_test -q
           pytest -o addopts='' tests/test_cli_slack.py::test_cmd_slack_notify -q
           pytest -o addopts='' tests/test_slack_bot.py -q
+          pytest -o addopts='' tests/test_slack_commands.py -q
           pytest -o addopts='' tests/test_scaffold.py -q
           pytest -o addopts='' tests/test_board_priority.py -q
           pytest -o addopts='' tests/test_installation.py -q

--- a/src/slack/__init__.py
+++ b/src/slack/__init__.py
@@ -4,6 +4,7 @@ import requests
 
 from .bot import SlackBot
 from .commands import SlashCommandHandler
+from .mapping import SlackGitHubMapper
 from .oauth import SlackOAuth, verify_slack_signature
 
 
@@ -30,5 +31,6 @@ __all__ = [
     "SlackOAuth",
     "verify_slack_signature",
     "SlashCommandHandler",
+    "SlackGitHubMapper",
     "SlackBot",
 ]

--- a/src/slack/commands.py
+++ b/src/slack/commands.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Dict, List, Optional
+
+from .mapping import SlackGitHubMapper
 
 
 class SlashCommandHandler:
-    """Basic slash command handler."""
+    """Handle Slack slash commands."""
 
-    def __init__(self, task_manager) -> None:
+    def __init__(
+        self, task_manager, mapper: Optional[SlackGitHubMapper] = None
+    ) -> None:
         self.task_manager = task_manager
+        self.mapper = mapper or SlackGitHubMapper()
 
     def handle_command(self, command: str, args: Dict) -> Dict:
         if command == "/autonomy next":
@@ -19,21 +24,75 @@ class SlashCommandHandler:
         return self.handle_help_command()
 
     def handle_next_command(self, args: Dict) -> Dict:
-        issue = self.task_manager.get_next_task()
+        slack_user = args.get("user_id") or args.get("user")
+        github_user = self.mapper.get_github_user(slack_user) if slack_user else None
+        issue = self.task_manager.get_next_task(assignee=github_user)
         if not issue:
-            return {"text": "No tasks found"}
-        return {"text": f"Next task: #{issue['number']} - {issue['title']}"}
+            return {"text": "No tasks found", "response_type": "ephemeral"}
+        blocks = self.format_task_blocks(issue)
+        return {
+            "text": f"Next task: #{issue['number']}",
+            "blocks": blocks,
+            "response_type": "ephemeral",
+        }
 
     def handle_update_command(self, args: Dict) -> Dict:
-        issue = args.get("issue")
-        status = args.get("status")
-        notes = args.get("notes")
-        if self.task_manager.update_task(issue, status=status, notes=notes):
-            return {"text": "Issue updated"}
-        return {"text": "Failed to update issue"}
+        slack_user = args.get("user_id") or args.get("user")
+        issue_str = args.get("text", "").strip() or args.get("issue")
+        if not issue_str or not issue_str.isdigit():
+            return {
+                "text": "Usage: `/autonomy update <issue-number>`",
+                "response_type": "ephemeral",
+            }
+        issue_number = int(issue_str)
+        success = self.task_manager.update_task(
+            issue_number,
+            status="completed",
+            notes=f"Updated via Slack by {slack_user}",
+        )
+        if success:
+            return {
+                "text": f"\u2705 Issue #{issue_number} updated successfully!",
+                "response_type": "in_channel",
+            }
+        return {
+            "text": f"\u274c Failed to update issue #{issue_number}",
+            "response_type": "ephemeral",
+        }
 
     def handle_status_command(self, args: Dict) -> Dict:
-        return {"text": "Status command not implemented"}
+        slack_user = args.get("user_id") or args.get("user")
+        github_user = self.mapper.get_github_user(slack_user) if slack_user else None
+        tasks = self.task_manager.list_tasks(assignee=github_user)
+        in_progress = len(
+            [
+                t
+                for t in tasks
+                if "in-progress"
+                in [
+                    l if isinstance(l, str) else l.get("name")
+                    for l in t.get("labels", [])
+                ]
+            ]
+        )
+        blocks = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*Status for {github_user}*"},
+            },
+            {
+                "type": "fields",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"*Open Tasks:* {len(tasks)}"},
+                    {"type": "mrkdwn", "text": f"*In Progress:* {in_progress}"},
+                ],
+            },
+        ]
+        return {
+            "text": f"Status for {github_user}",
+            "blocks": blocks,
+            "response_type": "ephemeral",
+        }
 
     def handle_help_command(self) -> Dict:
         return {
@@ -41,3 +100,43 @@ class SlashCommandHandler:
                 "Available commands: /autonomy next, /autonomy update, /autonomy status"
             )
         }
+
+    # --------------------- helpers ---------------------
+    def format_task_blocks(self, issue: Dict[str, Any]) -> List[Dict[str, Any]]:
+        labels = [
+            l if isinstance(l, str) else l.get("name") for l in issue.get("labels", [])
+        ]
+        issue_mgr = getattr(self.task_manager, "issue_manager", None)
+        owner = issue_mgr.owner if issue_mgr else "owner"
+        repo = issue_mgr.repo if issue_mgr else "repo"
+        return [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*#{issue['number']}: {issue['title']}*",
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Labels: {', '.join(labels)}",
+                    }
+                ],
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "View on GitHub"},
+                        "url": f"https://github.com/{owner}/{repo}/issues/{issue['number']}",
+                    }
+                ],
+            },
+        ]
+
+    def handle_error(self, exc: Exception) -> Dict[str, str]:
+        return {"text": f"Error: {exc}", "response_type": "ephemeral"}

--- a/src/slack/commands.py
+++ b/src/slack/commands.py
@@ -66,12 +66,12 @@ class SlashCommandHandler:
         tasks = self.task_manager.list_tasks(assignee=github_user)
         in_progress = len(
             [
-                t
-                for t in tasks
+                task
+                for task in tasks
                 if "in-progress"
                 in [
-                    l if isinstance(l, str) else l.get("name")
-                    for l in t.get("labels", [])
+                    label if isinstance(label, str) else label.get("name")
+                    for label in task.get("labels", [])
                 ]
             ]
         )
@@ -104,7 +104,8 @@ class SlashCommandHandler:
     # --------------------- helpers ---------------------
     def format_task_blocks(self, issue: Dict[str, Any]) -> List[Dict[str, Any]]:
         labels = [
-            l if isinstance(l, str) else l.get("name") for l in issue.get("labels", [])
+            label if isinstance(label, str) else label.get("name")
+            for label in issue.get("labels", [])
         ]
         issue_mgr = getattr(self.task_manager, "issue_manager", None)
         owner = issue_mgr.owner if issue_mgr else "owner"

--- a/src/slack/mapping.py
+++ b/src/slack/mapping.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from ..core.secret_vault import SecretVault
+
+
+class SlackGitHubMapper:
+    """Map Slack users to GitHub usernames using a local JSON file."""
+
+    def __init__(self, vault: SecretVault | None = None) -> None:
+        self.vault = vault or SecretVault()
+        self.mapping_file = Path.home() / ".autonomy" / "slack_github_mapping.json"
+
+    def load_mappings(self) -> Dict[str, str]:
+        if self.mapping_file.exists():
+            with open(self.mapping_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+        return {}
+
+    def save_mappings(self, data: Dict[str, str]) -> None:
+        self.mapping_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.mapping_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def get_github_user(self, slack_user: str) -> str:
+        mappings = self.load_mappings()
+        return mappings.get(slack_user, slack_user)
+
+    def set_mapping(self, slack_user: str, github_user: str) -> None:
+        mappings = self.load_mappings()
+        mappings[slack_user] = github_user
+        self.save_mappings(mappings)

--- a/tests/test_slack_commands.py
+++ b/tests/test_slack_commands.py
@@ -1,0 +1,67 @@
+from src.core.secret_vault import SecretVault
+from src.slack.commands import SlashCommandHandler
+from src.slack.mapping import SlackGitHubMapper
+
+
+class DummyTM:
+    def __init__(self):
+        self.updated = None
+
+    def get_next_task(self, assignee=None, team=None):
+        assert assignee == "gh"
+        return {"number": 1, "title": "task", "labels": ["priority-high"]}
+
+    def update_task(self, issue_number, status=None, notes=None, done=False):
+        self.updated = (issue_number, status, notes)
+        return True
+
+    def list_tasks(self, assignee=None, team=None, limit=10):
+        assert assignee == "gh"
+        return [
+            {"number": 1, "title": "t1", "labels": ["in-progress"]},
+            {"number": 2, "title": "t2", "labels": []},
+        ]
+
+
+def test_slack_github_mapper(tmp_path):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    mapper = SlackGitHubMapper(vault)
+    mapper.mapping_file = tmp_path / "m.json"
+    mapper.set_mapping("U", "gh")
+    assert mapper.get_github_user("U") == "gh"
+    assert mapper.get_github_user("X") == "X"
+
+
+def test_slash_next_with_mapping(tmp_path):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    mapper = SlackGitHubMapper(vault)
+    mapper.mapping_file = tmp_path / "m.json"
+    mapper.set_mapping("U", "gh")
+    handler = SlashCommandHandler(DummyTM(), mapper)
+    resp = handler.handle_command("/autonomy next", {"user_id": "U"})
+    assert resp["response_type"] == "ephemeral"
+    assert "Next task" in resp["text"]
+    assert resp["blocks"][0]["type"] == "section"
+
+
+def test_slash_update_success(tmp_path):
+    handler = SlashCommandHandler(DummyTM())
+    resp = handler.handle_command("/autonomy update", {"text": "1", "user": "U"})
+    assert "updated successfully" in resp["text"]
+
+
+def test_slash_update_usage(tmp_path):
+    handler = SlashCommandHandler(DummyTM())
+    resp = handler.handle_command("/autonomy update", {"text": "abc"})
+    assert "Usage" in resp["text"]
+
+
+def test_slash_status(tmp_path):
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    mapper = SlackGitHubMapper(vault)
+    mapper.mapping_file = tmp_path / "m.json"
+    mapper.set_mapping("U", "gh")
+    handler = SlashCommandHandler(DummyTM(), mapper)
+    resp = handler.handle_command("/autonomy status", {"user_id": "U"})
+    assert resp["response_type"] == "ephemeral"
+    assert resp["blocks"][1]["type"] == "fields"


### PR DESCRIPTION
## Summary
- implement SlackGitHubMapper for Slack<->GitHub user mapping
- extend SlashCommandHandler to support next/update/status commands
- format rich Slack responses
- add unit tests for slash command handler and mapper
- run new test in CI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b548f2630832da287189fa07bf6e1