### PR TITLE
Implement Slack notifications scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           pytest -o addopts='' tests/test_cli_slack.py::test_cmd_slack_notify -q
           pytest -o addopts='' tests/test_slack_bot.py -q
           pytest -o addopts='' tests/test_slack_commands.py -q
+          pytest -o addopts='' tests/test_slack_notifications.py -q
           pytest -o addopts='' tests/test_scaffold.py -q
           pytest -o addopts='' tests/test_board_priority.py -q
           pytest -o addopts='' tests/test_installation.py -q

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ htmlcov/
 # Eggs
 *.egg-info/
 
+# Test logs
+*.log
+
 # Local vault
 .autonomy/

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -29,8 +29,13 @@ from .github.token_storage import (
 )
 from .planning.plan_manager import PlanManager
 from .slack import (
+    BacklogDoctorNotifier,
+    MetricsDashboard,
+    NotificationScheduler,
+    NotificationTemplates,
     SlackOAuth,
     SlashCommandHandler,
+    SystemNotifier,
     get_slack_auth_info,
     verify_slack_signature,
 )
@@ -76,6 +81,11 @@ __all__ = [
     "SlackOAuth",
     "SlashCommandHandler",
     "verify_slack_signature",
+    "BacklogDoctorNotifier",
+    "MetricsDashboard",
+    "SystemNotifier",
+    "NotificationTemplates",
+    "NotificationScheduler",
     "verify_installation",
     "create_app",
 ]

--- a/src/slack/__init__.py
+++ b/src/slack/__init__.py
@@ -5,6 +5,13 @@ import requests
 from .bot import SlackBot
 from .commands import SlashCommandHandler
 from .mapping import SlackGitHubMapper
+from .notifications import (
+    BacklogDoctorNotifier,
+    MetricsDashboard,
+    NotificationScheduler,
+    NotificationTemplates,
+    SystemNotifier,
+)
 from .oauth import SlackOAuth, verify_slack_signature
 
 
@@ -33,4 +40,9 @@ __all__ = [
     "SlashCommandHandler",
     "SlackGitHubMapper",
     "SlackBot",
+    "BacklogDoctorNotifier",
+    "MetricsDashboard",
+    "SystemNotifier",
+    "NotificationTemplates",
+    "NotificationScheduler",
 ]

--- a/src/slack/notifications.py
+++ b/src/slack/notifications.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Dict, List
+
+from .bot import SlackBot
+
+
+@dataclass
+class Issue:
+    number: int
+    title: str
+    html_url: str
+    stale_days: int = 0
+
+
+@dataclass
+class DuplicatePair:
+    issue1: Issue
+    issue2: Issue
+    similarity: int
+
+
+@dataclass
+class BacklogFindings:
+    stale_issues: List[Issue]
+    duplicates: List[DuplicatePair]
+    oversized: List[Issue]
+    health_score: int
+
+
+@dataclass
+class WeeklyMetrics:
+    week_start: datetime
+    completed_issues: int
+    avg_time_to_task: float
+    approval_rate: int
+    weekly_active_users: int
+
+
+@dataclass
+class UndoOperation:
+    description: str
+    actor: str
+    hash: str
+
+
+class NotificationTemplates:
+    """Reusable Slack message formatting helpers."""
+
+    @staticmethod
+    def format_stale_issues(stale_issues: List[Issue]) -> Dict:
+        issue_list = []
+        for issue in stale_issues[:5]:
+            issue_list.append(
+                f"\u2022 <{issue.html_url}|#{issue.number}> - {issue.title} (stale for {issue.stale_days} days)"
+            )
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*\U0001f578\ufe0f Stale Issues ({len(stale_issues)})*\n"
+                + "\n".join(issue_list),
+            },
+        }
+
+    @staticmethod
+    def format_duplicates(duplicates: List[DuplicatePair]) -> Dict:
+        duplicate_list = []
+        for dup in duplicates[:3]:
+            text = (
+                f"\u2022 <{dup.issue1.html_url}|#{dup.issue1.number}>"
+                f" \u2194 <{dup.issue2.html_url}|#{dup.issue2.number}>"
+                f" ({dup.similarity}% similar)"
+            )
+            duplicate_list.append(text)
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*\U0001f501 Potential Duplicates ({len(duplicates)})*\n"
+                + "\n".join(duplicate_list),
+            },
+        }
+
+
+class BacklogDoctorNotifier:
+    """Send backlog doctor reports to Slack."""
+
+    def __init__(self, slack_client: SlackBot) -> None:
+        self.slack_client = slack_client
+
+    def send_nightly_report(self, channel: str, findings: BacklogFindings) -> bool:
+        blocks: List[Dict] = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "\U0001f3e5 Nightly Backlog Doctor Report",
+                },
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Stale Issues:* {len(findings.stale_issues)}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Duplicates:* {len(findings.duplicates)}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Oversized:* {len(findings.oversized)}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Health Score:* {findings.health_score}%",
+                    },
+                ],
+            },
+        ]
+        if findings.stale_issues:
+            blocks.append(
+                NotificationTemplates.format_stale_issues(findings.stale_issues)
+            )
+        if findings.duplicates:
+            blocks.append(NotificationTemplates.format_duplicates(findings.duplicates))
+        return self.slack_client.post_message(
+            channel=channel,
+            text="Nightly Backlog Doctor Report",
+            blocks=blocks,
+        )
+
+
+class MetricsDashboard:
+    """Send weekly metrics summaries."""
+
+    def __init__(self, slack_client: SlackBot) -> None:
+        self.slack_client = slack_client
+
+    def send_weekly_metrics(self, channel: str, metrics: WeeklyMetrics) -> bool:
+        blocks = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "\U0001f4ca Weekly Team Metrics",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Week of {metrics.week_start.strftime('%B %d')}*",
+                },
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Issues Completed:* {metrics.completed_issues}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Avg Time to Task:* {metrics.avg_time_to_task}s",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Bot Approval Rate:* {metrics.approval_rate}%",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Weekly Active Users:* {metrics.weekly_active_users}",
+                    },
+                ],
+            },
+        ]
+        return self.slack_client.post_message(
+            channel=channel,
+            text="Weekly Team Metrics",
+            blocks=blocks,
+        )
+
+
+class SystemNotifier:
+    """Send system related notifications."""
+
+    def __init__(self, slack_client: SlackBot) -> None:
+        self.slack_client = slack_client
+
+    def send_undo_confirmation(self, channel: str, operation: UndoOperation) -> bool:
+        blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"\u2705 *Undo Operation Completed*\n{operation.description}",
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Performed by: {operation.actor} | Hash: `{operation.hash}`",
+                    }
+                ],
+            },
+        ]
+        return self.slack_client.post_message(
+            channel=channel,
+            text="Undo operation completed",
+            blocks=blocks,
+        )
+
+
+class NotificationScheduler:
+    """Simple in-memory notification scheduler."""
+
+    def __init__(self, slack_client: SlackBot) -> None:
+        self.slack_client = slack_client
+        self.schedule: Dict[str, Dict[str, Any]] = {}
+
+    def schedule_daily(
+        self, name: str, time: str, func: Callable[[str], None], channel: str
+    ) -> None:
+        self.schedule[name] = {
+            "frequency": "daily",
+            "time": time,
+            "func": func,
+            "channel": channel,
+        }
+
+    def schedule_weekly(
+        self, name: str, day: str, time: str, func: Callable[[str], None], channel: str
+    ) -> None:
+        self.schedule[name] = {
+            "frequency": "weekly",
+            "day": day,
+            "time": time,
+            "func": func,
+            "channel": channel,
+        }
+
+    def run_scheduler(self) -> None:
+        for entry in self.schedule.values():
+            entry["func"](entry["channel"])

--- a/tests/test_slack_notifications.py
+++ b/tests/test_slack_notifications.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+
+from src.slack.notifications import (
+    BacklogDoctorNotifier,
+    BacklogFindings,
+    DuplicatePair,
+    Issue,
+    MetricsDashboard,
+    NotificationScheduler,
+    SystemNotifier,
+    UndoOperation,
+    WeeklyMetrics,
+)
+
+
+class DummySlackBot:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def post_message(self, channel: str, text: str, blocks=None):
+        self.calls.append((channel, text, blocks))
+        return True
+
+
+def test_backlog_doctor_notifier():
+    bot = DummySlackBot()
+    notifier = BacklogDoctorNotifier(bot)  # type: ignore[arg-type]
+    findings = BacklogFindings(
+        stale_issues=[Issue(1, "Old", "http://i", 10)],
+        duplicates=[
+            DuplicatePair(Issue(2, "A", "http://a"), Issue(3, "B", "http://b"), 95)
+        ],
+        oversized=[],
+        health_score=80,
+    )
+    assert notifier.send_nightly_report("C", findings)
+    ch, text, blocks = bot.calls[0]
+    assert ch == "C"
+    assert "Backlog Doctor" in text
+    assert blocks[0]["type"] == "header"
+
+
+def test_metrics_dashboard():
+    bot = DummySlackBot()
+    dash = MetricsDashboard(bot)  # type: ignore[arg-type]
+    metrics = WeeklyMetrics(
+        week_start=datetime(2024, 1, 1),
+        completed_issues=5,
+        avg_time_to_task=1.2,
+        approval_rate=90,
+        weekly_active_users=3,
+    )
+    assert dash.send_weekly_metrics("C", metrics)
+    assert bot.calls
+
+
+def test_system_notifier():
+    bot = DummySlackBot()
+    sysn = SystemNotifier(bot)  # type: ignore[arg-type]
+    op = UndoOperation("Did stuff", "me", "h")
+    assert sysn.send_undo_confirmation("C", op)
+    assert bot.calls
+
+
+def test_notification_scheduler():
+    bot = DummySlackBot()
+    sched = NotificationScheduler(bot)  # type: ignore[arg-type]
+
+    called = {}
+
+    def func(channel: str):
+        called[channel] = True
+
+    sched.schedule_daily("d", "09:00", func, "C")
+    sched.schedule_weekly("w", "mon", "10:00", func, "C")
+    sched.run_scheduler()
+    assert called["C"]

--- a/tests/test_token_storage.py
+++ b/tests/test_token_storage.py
@@ -1,7 +1,4 @@
-from src.github.token_storage import (
-    SecureTokenStorage,
-    refresh_token_if_needed,
-)
+from src.github.token_storage import SecureTokenStorage, refresh_token_if_needed
 
 
 class DummyKeyring:


### PR DESCRIPTION
## Summary
- add Slack notifications module with basic classes
- export new notifications via package init
- expose notifications in Slack package
- test Slack notifications
- ignore log artifacts
- run new tests in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml src/__init__.py src/slack/__init__.py src/slack/notifications.py tests/test_slack_notifications.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be3639fc8832daf592bdc415f1ab7