### PR TITLE
Implement board cache CLI option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           pytest -o addopts='' tests/test_board_manager.py -q
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_board_init -q
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_board_init_custom_path -q
+          pytest -o addopts='' tests/test_cli_commands.py::test_cmd_board_init_arg_cache -q
           pytest -o addopts='' tests/test_github_device_flow.py -q
           pytest -o addopts='' tests/test_cli_auth.py::test_cmd_auth_login_oauth -q
           pytest -o addopts='' tests/test_slack_oauth.py -q

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -150,7 +150,11 @@ Environment Variables:
     # Board command
     board_parser = subparsers.add_parser("board", help="Manage project board")
     board_sub = board_parser.add_subparsers(dest="board_cmd")
-    board_sub.add_parser("init", help="Initialize board fields")
+    board_init_parser = board_sub.add_parser("init", help="Initialize board fields")
+    board_init_parser.add_argument(
+        "--cache",
+        help="Path to field cache file",
+    )
 
     # Audit command
     audit_parser = subparsers.add_parser("audit", help="Audit related commands")
@@ -500,7 +504,11 @@ def cmd_board_init(manager: WorkflowManager, args) -> int:
     """Initialize project board fields."""
     from ..github.board_manager import BoardManager
 
-    cache_path = Path(manager.config.board_cache_path).expanduser()
+    cache_path = (
+        Path(args.cache).expanduser()
+        if getattr(args, "cache", None)
+        else Path(manager.config.board_cache_path).expanduser()
+    )
     bm = BoardManager(
         manager.github_token,
         manager.owner,

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -245,6 +245,25 @@ def test_cmd_board_init_custom_path(monkeypatch, tmp_path: Path):
     assert custom.exists()
 
 
+def test_cmd_board_init_arg_cache(monkeypatch, tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    captured = {}
+
+    class DummyBM:
+        def __init__(self, token, owner, repo, cache_path=None):
+            captured["path"] = cache_path
+
+        def init_board(self):
+            return {}
+
+    monkeypatch.setattr("src.github.board_manager.BoardManager", DummyBM)
+
+    via_arg = tmp_path / "via_arg.json"
+    args = SimpleNamespace(cache=str(via_arg))
+    assert cmd_board_init(manager, args) == 0
+    assert Path(captured["path"]) == via_arg
+
+
 def test_cmd_doctor_run(monkeypatch, tmp_path: Path):
     manager = DummyManager(tmp_path)
     manager.issue_manager = object()


### PR DESCRIPTION
## Summary
- allow setting custom cache path with `--cache` for `autonomy board init`
- add unit test for the new CLI flag
- run new test in CI board scaffolding job

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687dbb40b314832dabefb9e6add26454