### PR TITLE
Implement package verification utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           pytest -o addopts='' tests/test_scaffold.py -q
           pytest -o addopts='' tests/test_board_priority.py -q
           pytest -o addopts='' tests/test_installation.py -q
+          pytest -o addopts='' tests/test_distribution.py -q
           pytest -o addopts='' tests/test_no_mcp_references.py -q
           pytest -o addopts='' tests/test_token_storage.py -q
           pytest -o addopts='' tests/test_backlog_doctor.py -q

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -44,6 +44,8 @@ __author__ = "Mehul Bhardwaj"
 __email__ = "mehul@example.com"
 __license__ = "MIT"
 
+from .utils.distribution import check_for_updates, verify_installation
+
 __all__ = [
     # Core classes
     "WorkflowManager",
@@ -81,6 +83,8 @@ __all__ = [
     "SystemNotifier",
     "NotificationTemplates",
     "NotificationScheduler",
+    "verify_installation",
+    "check_for_updates",
     "create_app",
 ]
 

--- a/src/utils/distribution.py
+++ b/src/utils/distribution.py
@@ -1,0 +1,30 @@
+import importlib
+
+import httpx
+from packaging import version
+
+from .. import __version__
+
+
+def verify_installation() -> bool:
+    """Verify package installation and basic imports."""
+    try:
+        importlib.import_module("src.cli.main")
+        importlib.import_module("src.core.config")
+        return True
+    except Exception:
+        return False
+
+
+def check_for_updates() -> None:
+    """Check PyPI for newer versions and print upgrade hint."""
+    try:
+        resp = httpx.get("https://pypi.org/pypi/autonomy/json", timeout=5)
+        resp.raise_for_status()
+        latest = resp.json()["info"]["version"]
+        if version.parse(latest) > version.parse(__version__):
+            print(f"\U0001f4e6 Update available: {__version__} → {latest}")
+            print("Run: pipx upgrade autonomy")
+    except Exception:
+        # Fail silently on network or parsing errors
+        pass

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,0 +1,30 @@
+from src.utils.distribution import check_for_updates, verify_installation
+
+
+def test_verify_installation():
+    assert verify_installation()
+
+
+def test_check_for_updates(monkeypatch):
+    logs = []
+
+    class Resp:
+        def __init__(self, version):
+            self._version = version
+
+        def json(self):
+            return {"info": {"version": self._version}}
+
+        def raise_for_status(self):
+            pass
+
+    def dummy_get(url, timeout=5):
+        return Resp("9.9.9")
+
+    monkeypatch.setattr("httpx.get", dummy_get)
+    monkeypatch.setattr(
+        "builtins.print", lambda *a, **k: logs.append(" ".join(map(str, a)))
+    )
+
+    check_for_updates()
+    assert any("Update available" in line for line in logs)


### PR DESCRIPTION
## Summary
- add `verify_installation` and `check_for_updates` helpers
- export the new helpers from the main package
- test distribution utilities
- run distribution tests in CI

## Testing
- `pytest -q`
- `flake8 --max-line-length=120 .`
- `black --check src/utils/distribution.py src/__init__.py tests/test_distribution.py`
- `isort --check src/utils/distribution.py src/__init__.py tests/test_distribution.py`
- `mypy src tests`

------
https://chatgpt.com/codex/tasks/task_e_687f37dd8664832da2a4cbbc6432d212