### PR TITLE
Implement week 3 CLI features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,4 +91,6 @@ jobs:
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_pin_unpin_and_list -q
           pytest -o addopts='' tests/test_api_server.py -q
           pytest -o addopts='' tests/test_ranking_engine.py -q
+          pytest -o addopts='' tests/test_planning_workflow.py -q
+          pytest -o addopts='' tests/test_cli_planning.py -q
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -9,6 +9,7 @@ Mehul Bhardwaj.
 from .api import create_app
 from .core.agents import BaseAgent, PMAgent, QAAgent, SDEAgent
 from .core.config import WorkflowConfig
+from .core.platform import AutonomyPlatform, BaseWorkflow
 from .core.secret_vault import SecretVault
 from .core.workflow_manager import WorkflowManager
 from .github import (
@@ -50,6 +51,8 @@ __all__ = [
     # Core classes
     "WorkflowManager",
     "WorkflowConfig",
+    "AutonomyPlatform",
+    "BaseWorkflow",
     # Agents
     "BaseAgent",
     "PMAgent",

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class WorkflowState:
+    """State shared between workflow steps."""
+
+    data: Dict[str, Any] = field(default_factory=dict)
+    issue_id: Optional[str] = None
+    human_approval_needed: bool = False
+    next_workflows: List[str] = field(default_factory=list)
+
+
+@dataclass
+class WorkflowResult:
+    """Result returned by workflow execution."""
+
+    success: bool
+    state: WorkflowState
+    outputs: Dict[str, Any] = field(default_factory=dict)
+    next_action: Optional[str] = None
+    requires_security_review: bool = False
+    has_code_changes: bool = False
+
+
+@dataclass
+class Issue:
+    id: str
+    title: str
+    body: str
+    labels: List[str] = field(default_factory=list)
+    assignee: Optional[str] = None
+    milestone: Optional[str] = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class TeamContext:
+    repository: str
+    team_members: List[str] = field(default_factory=list)
+    preferences: Dict[str, Any] = field(default_factory=dict)
+    workflow_settings: Dict[str, Any] = field(default_factory=dict)

--- a/src/core/platform.py
+++ b/src/core/platform.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Type
+
+from .workflow import BaseWorkflow
+
+
+class Mem0Client:  # pragma: no cover - simple stub
+    """Extremely small in-memory store used for tests."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def search(self, query: str) -> str:
+        return self.store.get(query, "")
+
+    def add(self, data: dict[str, str]) -> bool:
+        self.store.update(data)
+        return True
+
+
+class OpenRouterClient:  # pragma: no cover - simple stub
+    """Return simple echo responses for tests."""
+
+    def complete(self, messages):
+        if not messages:
+            return ""
+        content = messages[-1].get("content", "")
+        return f"LLM:{content}"
+
+
+class GitHubTools:  # pragma: no cover - simple stub
+    def get_issue(self, issue_number: int) -> dict:
+        return {}
+
+
+class SlackTools:  # pragma: no cover - simple stub
+    def post_message(self, channel: str, text: str) -> bool:
+        return True
+
+
+class AutonomyPlatform:
+    """Shared foundation for all workflows."""
+
+    def __init__(self):
+        self.memory = Mem0Client()
+        self.llm = OpenRouterClient()
+        self.github = GitHubTools()
+        self.slack = SlackTools()
+
+    def create_workflow(self, workflow_class: Type[BaseWorkflow]) -> BaseWorkflow:
+        return workflow_class(
+            memory=self.memory,
+            llm=self.llm,
+            github=self.github,
+            slack=self.slack,
+        )

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+from .models import WorkflowResult, WorkflowState
+
+StateGraph = Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]]
+
+
+class BaseWorkflow:
+    """Minimal workflow with sequential step execution."""
+
+    def __init__(self, memory, llm, github, slack):
+        self.memory = memory
+        self.llm = llm
+        self.github = github
+        self.slack = slack
+        self.graph = self._build_graph()
+
+    # ------------------------------------------------------------------
+    def _build_graph(self) -> StateGraph:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    def execute(self, state: Dict[str, Any]) -> WorkflowResult:
+        current = state.copy()
+        for step, func in self.graph.items():
+            current = func(current)
+        return WorkflowResult(success=True, state=WorkflowState(data=current))

--- a/src/planning/config.py
+++ b/src/planning/config.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class PlanningConfig:
+    """Repository specific planning configuration."""
+
+    ranking_weights: Dict[str, float] = field(
+        default_factory=lambda: {
+            "priority_label": 0.4,
+            "sprint_proximity": 0.3,
+            "issue_age": 0.1,
+            "dependency_urgency": 0.2,
+        }
+    )
+    team_preferences: Dict[str, str] = field(default_factory=dict)

--- a/src/planning/workflow.py
+++ b/src/planning/workflow.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..core.models import WorkflowResult
+from ..core.platform import BaseWorkflow
+from ..tasks.ranking import RankingEngine
+from .config import PlanningConfig
+
+
+class PlanningWorkflow(BaseWorkflow):
+    """Simplified planning workflow."""
+
+    def __init__(
+        self, memory, llm, github, slack, config: PlanningConfig | None = None
+    ):
+        self.config = config or PlanningConfig()
+        self.ranking = RankingEngine()
+        super().__init__(memory, llm, github, slack)
+
+    # ------------------------------------------------------------------
+    def _build_graph(self):
+        return {
+            "analyze_issue": self.analyze_issue,
+            "rank_priority": self.rank_priority,
+            "decompose": self.decompose,
+            "route": self.route,
+            "assign": self.assign,
+            "plan": self.plan,
+            "approve": self.approve,
+        }
+
+    # Steps -------------------------------------------------------------
+    def analyze_issue(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Analyze issue using memory context and LLM."""
+        title = state.get("title", "")
+        context = self.memory.search(f"similar:{title}")
+        prompt = f"Analyze {title}. Context: {context}"
+        analysis = self.llm.complete([{"role": "user", "content": prompt}])
+        state["analysis"] = analysis or f"analysis of {title}"
+        return state
+
+    def rank_priority(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        issue = {
+            "labels": state.get("labels", []),
+            "created_at": state.get("created_at"),
+        }
+        score = self.ranking.score_issue(issue)
+        state["priority_score"] = score
+        return state
+
+    def decompose(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Break down work using LLM and store in memory."""
+        analysis = state.get("analysis", "")
+        text = self.llm.complete(
+            [{"role": "user", "content": f"Decompose: {analysis}"}]
+        )
+        tasks = [t.strip() for t in text.split(";") if t.strip()] or ["task1"]
+        state["tasks"] = tasks
+        self.memory.add({f"tasks:{state.get('title','')}": text})
+        return state
+
+    def route(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Determine additional workflows needed."""
+        analysis = state.get("analysis", "").lower()
+        state["requires_security_review"] = any(
+            k in analysis for k in ["auth", "security", "token"]
+        )
+        state["requires_docs"] = any(k in analysis for k in ["api", "public"])
+        return state
+
+    def assign(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Suggest assignment based on team data in memory."""
+        members = self.memory.search("team_members")
+        if isinstance(members, str):
+            choices = [m.strip() for m in members.split(",") if m.strip()]
+        else:
+            choices = []
+        state["assignee"] = choices[0] if choices else "alice"
+        return state
+
+    def plan(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate final plan description."""
+        tasks = ", ".join(state.get("tasks", []))
+        plan = self.llm.complete([{"role": "user", "content": f"Plan for: {tasks}"}])
+        state["plan"] = plan or "basic plan"
+        return state
+
+    def approve(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Record approval and learn outcome."""
+        state["approved"] = True
+        self.memory.add({"last_plan": state.get("plan", "")})
+        return state
+
+    # Public API -------------------------------------------------------
+    def run(self, issue: Dict[str, Any]) -> WorkflowResult:
+        result = self.execute(issue)
+        result.requires_security_review = result.state.data.get(
+            "requires_security_review", False
+        )
+        result.has_code_changes = True
+        return result

--- a/src/tasks/ranking.py
+++ b/src/tasks/ranking.py
@@ -50,8 +50,14 @@ class RankingConfig:
 class RankingEngine:
     """Multi-signal ranking engine for issues."""
 
-    def __init__(self, config: Optional[RankingConfig] = None) -> None:
+    def __init__(
+        self,
+        config: Optional[RankingConfig] = None,
+        *,
+        config_path: Path | None = None,
+    ) -> None:
         self.config = config or RankingConfig()
+        self.config.load_from_file(config_path or Path(".autonomy.yml"))
 
     # ------------------------------------------------------------------
     def score_issue(

--- a/src/tasks/task_manager.py
+++ b/src/tasks/task_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from ..github.issue_manager import IssueManager
@@ -17,11 +18,14 @@ class TaskManager:
         repo: str,
         pinned_store: PinnedItemsStore | None = None,
         ranking_config: RankingConfig | None = None,
+        config_path: str | None = None,
     ) -> None:
         self.issue_manager = IssueManager(github_token, owner, repo)
         self.pinned_store = pinned_store or PinnedItemsStore()
         self.project_id = f"{owner}/{repo}"
-        self.ranking = RankingEngine(ranking_config)
+        self.ranking = RankingEngine(
+            ranking_config, config_path=Path(config_path) if config_path else None
+        )
 
     # -------------------------- retrieval helpers ---------------------------
     def _score_issue(

--- a/tests/test_cli_planning.py
+++ b/tests/test_cli_planning.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.cli.main import cmd_explain, cmd_memory, cmd_plan, cmd_tune
+from src.core.config import WorkflowConfig
+
+
+class DummyIssueManager:
+    def __init__(self):
+        self.issues = {42: {"labels": [], "created_at": "2025-07-10T00:00:00Z"}}
+
+    def get_issue(self, num):
+        return self.issues.get(num)
+
+
+class DummyManager:
+    def __init__(self, tmp_path: Path):
+        self.owner = "o"
+        self.repo = "r"
+        self.github_token = "t"
+        self.workspace_path = tmp_path
+        self.config = WorkflowConfig()
+        self.issue_manager = DummyIssueManager()
+        from src.audit.logger import AuditLogger
+
+        self.audit_logger = AuditLogger(tmp_path / "audit.log", use_git=True)
+
+
+def test_cmd_plan(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace(issue=42)
+    assert cmd_plan(manager, args) == 0
+
+
+def test_cmd_explain(tmp_path: Path, capsys):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace(issue=42)
+    assert cmd_explain(manager, args) == 0
+    out = capsys.readouterr().out
+    assert "Score" in out
+
+
+def test_cmd_tune(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace(weights=["priority_label=1.0"])
+    assert cmd_tune(manager, args) == 0
+    assert Path(".autonomy.yml").exists()
+    Path(".autonomy.yml").unlink()
+
+
+def test_cmd_memory(tmp_path: Path, capsys, monkeypatch):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace()
+
+    class DummyMem:
+        def __init__(self):
+            self.store = {"k": "v"}
+
+    class DummyPlatform:
+        def __init__(self):
+            self.memory = DummyMem()
+
+    monkeypatch.setattr("src.core.platform.AutonomyPlatform", DummyPlatform)
+    assert cmd_memory(manager, args) == 0
+    out = capsys.readouterr().out
+    assert "k: v" in out

--- a/tests/test_planning_workflow.py
+++ b/tests/test_planning_workflow.py
@@ -1,0 +1,34 @@
+from src.core.platform import AutonomyPlatform
+from src.planning.workflow import PlanningWorkflow
+
+
+def test_planning_workflow_run():
+    platform = AutonomyPlatform()
+    wf = platform.create_workflow(PlanningWorkflow)
+    issue = {
+        "title": "Add login",
+        "labels": ["priority-high"],
+        "created_at": "2025-07-10T00:00:00Z",
+    }
+    result = wf.run(issue)
+    data = result.state.data
+    assert result.success
+    assert data["analysis"].startswith("LLM:")
+    assert "priority_score" in data
+    assert data["approved"]
+    assert platform.memory.store.get("last_plan")
+
+
+def test_security_routing_and_assignment():
+    platform = AutonomyPlatform()
+    platform.memory.add({"team_members": "bob"})
+    wf = platform.create_workflow(PlanningWorkflow)
+    issue = {
+        "title": "Fix auth token leak",
+        "labels": ["bug"],
+        "created_at": "2025-07-10T00:00:00Z",
+    }
+    result = wf.run(issue)
+    data = result.state.data
+    assert data["requires_security_review"]
+    assert data["assignee"] == "bob"

--- a/tests/test_platform_foundation.py
+++ b/tests/test_platform_foundation.py
@@ -1,0 +1,29 @@
+from src.core.models import Issue, WorkflowState
+from src.core.platform import AutonomyPlatform, BaseWorkflow
+from src.planning.config import PlanningConfig
+
+
+class DummyWorkflow(BaseWorkflow):
+    def _build_graph(self):
+        return {"step": self.do_step}
+
+    def do_step(self, state):
+        state["done"] = True
+        return state
+
+
+def test_platform_and_workflow():
+    platform = AutonomyPlatform()
+    wf = platform.create_workflow(DummyWorkflow)
+    result = wf.execute({"x": 1})
+    assert result.success
+    assert result.state.data["done"] is True
+
+
+def test_models():
+    issue = Issue(id="1", title="t", body="b")
+    state = WorkflowState(issue_id="1")
+    cfg = PlanningConfig()
+    assert issue.title == "t"
+    assert state.issue_id == "1"
+    assert "priority_label" in cfg.ranking_weights

--- a/tests/test_ranking_engine.py
+++ b/tests/test_ranking_engine.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta, timezone
 
 from src.tasks.ranking import RankingConfig, RankingEngine
@@ -34,3 +35,15 @@ def test_custom_weights():
     newer = _make_issue(4, "priority-low", 0)
     older = _make_issue(5, "priority-low", 5)
     assert eng.score_issue(newer) > eng.score_issue(older)
+
+
+def test_load_weights_from_file(tmp_path):
+    cfg_file = tmp_path / ".autonomy.yml"
+    cfg_file.write_text("weights:\n  issue_age: 5.0\n")
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        eng = RankingEngine()
+        assert eng.config.weights["issue_age"] == 5.0
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- load ranking weights from `.autonomy.yml`
- expose stored patterns in `cmd_memory`
- support external ranking config in `TaskManager`
- cover new behaviour in planning CLI and ranking engine tests

## Testing
- `pre-commit run --files src/cli/main.py src/tasks/ranking.py src/tasks/task_manager.py tests/test_cli_planning.py tests/test_ranking_engine.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f405eaff4832d93f2aa6706a32844