### PR TITLE
Implement repository memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,4 +94,5 @@ jobs:
           pytest -o addopts='' tests/test_planning_workflow.py -q
           pytest -o addopts='' tests/test_openrouter.py -q
           pytest -o addopts='' tests/test_cli_planning.py -q
+          pytest -o addopts='' tests/test_mem0_client.py -q
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -597,8 +597,10 @@ def cmd_memory(manager: WorkflowManager, args) -> int:
     if not platform.memory.store:
         print("No patterns learned yet")
         return 0
-    for k, v in platform.memory.store.items():
-        print(f"{k}: {v}")
+    for repo, data in platform.memory.store.items():
+        print(f"Repository: {repo}")
+        for k, v in data.items():
+            print(f"  {k}: {v}")
     return 0
 
 

--- a/src/core/platform.py
+++ b/src/core/platform.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import OrderedDict
 from typing import Type
 
 from ..llm.openrouter import ModelSelector, OpenRouterClient
@@ -7,16 +8,31 @@ from .workflow import BaseWorkflow
 
 
 class Mem0Client:  # pragma: no cover - simple stub
-    """Extremely small in-memory store used for tests."""
+    """Minimal repository-scoped memory store for tests."""
 
-    def __init__(self) -> None:
-        self.store: dict[str, str] = {}
+    def __init__(self, max_entries: int = 50) -> None:
+        self.max_entries = max_entries
+        # Each repository gets its own ordered store of key -> value pairs
+        self.store: dict[str, OrderedDict[str, str]] = {}
 
-    def search(self, query: str) -> str:
-        return self.store.get(query, "")
+    def _get_repo_store(self, repo: str) -> OrderedDict[str, str]:
+        if repo not in self.store:
+            self.store[repo] = OrderedDict()
+        return self.store[repo]
+
+    def search(self, query: str, filter_metadata: dict | None = None) -> str:
+        """Return stored value filtered by repository."""
+        repo = filter_metadata.get("repository") if filter_metadata else "default"
+        return self.store.get(repo, {}).get(query, "")
 
     def add(self, data: dict[str, str]) -> bool:
-        self.store.update(data)
+        """Add data to repository-specific store with cleanup."""
+        repository = data.pop("repository", "default")
+        repo_store = self._get_repo_store(repository)
+        for key, value in data.items():
+            if len(repo_store) >= self.max_entries:
+                repo_store.popitem(last=False)
+            repo_store[key] = value
         return True
 
 

--- a/tests/test_cli_planning.py
+++ b/tests/test_cli_planning.py
@@ -54,7 +54,7 @@ def test_cmd_memory(tmp_path: Path, capsys, monkeypatch):
 
     class DummyMem:
         def __init__(self):
-            self.store = {"k": "v"}
+            self.store = {"default": {"k": "v"}}
 
     class DummyPlatform:
         def __init__(self):
@@ -63,4 +63,5 @@ def test_cmd_memory(tmp_path: Path, capsys, monkeypatch):
     monkeypatch.setattr("src.core.platform.AutonomyPlatform", DummyPlatform)
     assert cmd_memory(manager, args) == 0
     out = capsys.readouterr().out
+    assert "Repository: default" in out
     assert "k: v" in out

--- a/tests/test_mem0_client.py
+++ b/tests/test_mem0_client.py
@@ -1,0 +1,28 @@
+from src.core.platform import AutonomyPlatform, Mem0Client
+from src.planning.workflow import PlanningWorkflow
+
+
+def test_repository_isolation():
+    mem = Mem0Client()
+    mem.add({"k": "v1", "repository": "repo1"})
+    mem.add({"k": "v2", "repository": "repo2"})
+    assert mem.search("k", {"repository": "repo1"}) == "v1"
+    assert mem.search("k", {"repository": "repo2"}) == "v2"
+
+
+def test_memory_cleanup():
+    mem = Mem0Client(max_entries=2)
+    mem.add({"a": "1", "repository": "r"})
+    mem.add({"b": "2", "repository": "r"})
+    mem.add({"c": "3", "repository": "r"})
+    repo_store = mem.store["r"]
+    assert "a" not in repo_store and len(repo_store) == 2
+
+
+def test_learn_from_override():
+    platform = AutonomyPlatform()
+    wf = platform.create_workflow(PlanningWorkflow)
+    wf.learn_from_override("1", {"plan": "ai"}, {"plan": "human"}, repository="default")
+    repo_store = platform.memory.store["default"]
+    assert repo_store["ai_decision"] == "{'plan': 'ai'}"
+    assert repo_store["human_decision"] == "{'plan': 'human'}"

--- a/tests/test_planning_workflow.py
+++ b/tests/test_planning_workflow.py
@@ -9,6 +9,7 @@ def test_planning_workflow_run():
         "title": "Add login",
         "labels": ["priority-high"],
         "created_at": "2025-07-10T00:00:00Z",
+        "repository": "default",
     }
     result = wf.run(issue)
     data = result.state.data
@@ -16,17 +17,18 @@ def test_planning_workflow_run():
     assert data["analysis"].startswith("LLM:")
     assert "priority_score" in data
     assert data["approved"]
-    assert platform.memory.store.get("last_plan")
+    assert platform.memory.store["default"].get("last_plan")
 
 
 def test_security_routing_and_assignment():
     platform = AutonomyPlatform()
-    platform.memory.add({"team_members": "bob"})
+    platform.memory.add({"team_members": "bob", "repository": "default"})
     wf = platform.create_workflow(PlanningWorkflow)
     issue = {
         "title": "Fix auth token leak",
         "labels": ["bug"],
         "created_at": "2025-07-10T00:00:00Z",
+        "repository": "default",
     }
     result = wf.run(issue)
     data = result.state.data


### PR DESCRIPTION
## Summary
- implement repository-scoped `Mem0Client`
- integrate new memory system in planning workflow
- print memory grouped by repository in CLI
- adjust tests for new memory model and add unit tests
- run new memory tests in CI

## Testing
- `flake8 --max-line-length=120 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6b5c3e28832d8ffb39f622333fcb