### PR TITLE
Implement core tool registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,4 +95,5 @@ jobs:
           pytest -o addopts='' tests/test_openrouter.py -q
           pytest -o addopts='' tests/test_cli_planning.py -q
           pytest -o addopts='' tests/test_mem0_client.py -q
+          pytest -o addopts='' tests/test_tool_registry.py -q
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -39,6 +39,7 @@ from .slack import (
 )
 from .tasks.backlog_doctor import BacklogDoctor
 from .tasks.task_manager import TaskManager
+from .tools import GitHubTools, MemoryTools, SlackTools, ToolRegistry
 
 __version__ = "0.1.1"
 __author__ = "Mehul Bhardwaj"
@@ -86,6 +87,10 @@ __all__ = [
     "SystemNotifier",
     "NotificationTemplates",
     "NotificationScheduler",
+    "ToolRegistry",
+    "GitHubTools",
+    "SlackTools",
+    "MemoryTools",
     "verify_installation",
     "check_for_updates",
     "create_app",

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,8 @@
+"""Core tool registry and implementations."""
+
+from .github import GitHubTools
+from .memory import MemoryTools
+from .registry import ToolRegistry
+from .slack import SlackTools
+
+__all__ = ["ToolRegistry", "GitHubTools", "SlackTools", "MemoryTools"]

--- a/src/tools/github.py
+++ b/src/tools/github.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.github.issue_manager import Issue, IssueManager
+
+
+class GitHubTools:
+    """Wrapper around :class:`IssueManager` exposing simple methods."""
+
+    def __init__(self, manager: IssueManager) -> None:
+        self.manager = manager
+
+    def create_issue(
+        self, data: Dict[str, Any], milestone: Optional[int] = None
+    ) -> Optional[int]:
+        issue = Issue(**data)
+        return self.manager.create_issue(issue, milestone)
+
+    def list_issues(self, state: str = "open") -> List[Dict[str, Any]]:
+        return self.manager.list_issues(state=state)
+
+    def update_issue_labels(
+        self,
+        issue_number: int,
+        add_labels: Optional[List[str]] = None,
+        remove_labels: Optional[List[str]] = None,
+    ) -> bool:
+        return self.manager.update_issue_labels(issue_number, add_labels, remove_labels)
+
+    def add_comment(self, issue_number: int, comment: str) -> bool:
+        return self.manager.add_comment(issue_number, comment)

--- a/src/tools/memory.py
+++ b/src/tools/memory.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.core.platform import Mem0Client
+
+
+class MemoryTools:
+    """Wrapper for basic Mem0Client operations."""
+
+    def __init__(self, memory: Mem0Client) -> None:
+        self.memory = memory
+
+    def search(self, query: str, repository: str = "default") -> Any:
+        return self.memory.search(query, {"repository": repository})
+
+    def add(self, data: dict[str, str], repository: str = "default") -> bool:
+        payload = {**data, "repository": repository}
+        return self.memory.add(payload)

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from src.audit.logger import AuditLogger
+
+
+class ToolRegistry:
+    """Registry for tools with basic permission validation."""
+
+    def __init__(self, audit_logger: Optional[AuditLogger] = None) -> None:
+        self._tools: Dict[str, Any] = {}
+        self._permissions: Dict[str, str] = {}
+        self.audit_logger = audit_logger
+
+    def register_tool(self, name: str, tool: Any, permission: str = "read") -> None:
+        """Register ``tool`` with required ``permission``."""
+        self._tools[name] = tool
+        self._permissions[name] = permission
+
+    def execute_tool(
+        self,
+        name: str,
+        action: str,
+        *,
+        agent: Any,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Execute a tool action with permission and audit checks."""
+        params = params or {}
+        if name not in self._tools:
+            raise KeyError(f"Unknown tool: {name}")
+        required = self._permissions.get(name, "read")
+        agent_perms = getattr(agent, "permissions", [])
+        if required == "write" and not ({"write", "admin"} & set(agent_perms)):
+            raise PermissionError(f"Agent lacks permission for {name}")
+
+        tool = self._tools[name]
+        func: Callable = getattr(tool, action)
+        success = True
+        try:
+            result = func(**params)
+            return result
+        except Exception as e:  # pragma: no cover - unexpected errors
+            success = False
+            error = str(e)
+            raise
+        finally:
+            if self.audit_logger:
+                details = {
+                    "tool": name,
+                    "action": action,
+                    "agent": getattr(agent, "id", None),
+                    "params": params,
+                    "success": success,
+                }
+                if not success:
+                    details["error"] = error
+                self.audit_logger.log("tool_execute", details)

--- a/src/tools/slack.py
+++ b/src/tools/slack.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from src.slack.bot import SlackBot
+
+
+class SlackTools:
+    """Simple Slack tool wrapper."""
+
+    def __init__(self, bot: SlackBot) -> None:
+        self.bot = bot
+
+    def post_message(
+        self, channel: str, text: str, blocks: List[Dict[str, Any]] | None = None
+    ) -> bool:
+        return self.bot.post_message(channel=channel, text=text, blocks=blocks)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+
+from src.audit.logger import AuditLogger
+from src.tools import ToolRegistry
+
+
+class DummyTool:
+    def __init__(self) -> None:
+        self.called_with = None
+
+    def do(self, value: int) -> int:
+        self.called_with = value
+        return value * 2
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str, permissions: list[str]):
+        self.id = agent_id
+        self.permissions = permissions
+
+
+def test_permission_enforcement(tmp_path: Path) -> None:
+    registry = ToolRegistry(audit_logger=AuditLogger(tmp_path / "audit.log"))
+    tool = DummyTool()
+    registry.register_tool("dummy", tool, permission="write")
+    agent = DummyAgent("a1", ["read"])
+    with pytest.raises(PermissionError):
+        registry.execute_tool("dummy", "do", agent=agent, params={"value": 1})
+
+
+def test_audit_logging(tmp_path: Path) -> None:
+    registry = ToolRegistry(audit_logger=AuditLogger(tmp_path / "audit.log"))
+    tool = DummyTool()
+    registry.register_tool("dummy", tool, permission="write")
+    agent = DummyAgent("a2", ["write"])
+    result = registry.execute_tool("dummy", "do", agent=agent, params={"value": 2})
+    assert result == 4
+    entries = list(registry.audit_logger.iter_logs())
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["details"]["tool"] == "dummy"
+    assert entry["details"]["agent"] == "a2"
+    assert entry["details"]["success"] is True


### PR DESCRIPTION
## Summary
- implement new tool registry with permission checks
- add wrappers for GitHub, Slack and memory tools
- expose new tools in package
- add unit tests for registry behaviour
- run new tests in CI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f70ce1620832d99f43b78e419a0fc