### PR TITLE
Add settings UI for API key configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "requests>=2.25.0",
     "httpx>=0.25.0,<0.28",
     "fastapi>=0.111.0",
+    "python-multipart>=0.0.5",
     "click>=8.0.0",
     "pydantic>=2.7.4",
     "langgraph>=0.5.4",

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Settings</title>
+</head>
+<body>
+    <h1>Settings</h1>
+    <form method="post" action="/api/v1/settings">
+        <label>OpenRouter API Key
+            <input type="text" name="openrouter_api_key" value="{{ values.openrouter_api_key }}" />
+        </label><br/>
+        <label>Mem0 URL
+            <input type="text" name="mem0_url" value="{{ values.mem0_url }}" />
+        </label><br/>
+        <label>GitHub Token
+            <input type="text" name="github_token" value="{{ values.github_token }}" />
+        </label><br/>
+        <label>Slack Token
+            <input type="text" name="slack_token" value="{{ values.slack_token }}" />
+        </label><br/>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/tests/test_settings_ui.py
+++ b/tests/test_settings_ui.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from src.api.server import create_app
+from src.audit.logger import AuditLogger
+from src.core.secret_vault import SecretVault
+
+
+class DummyIssueManager:
+    owner = "o"
+    repo = "r"
+
+    def list_issues(self, state="open"):
+        return []
+
+
+def test_settings_page(tmp_path: Path):
+    dummy = DummyIssueManager()
+    vault = SecretVault(vault_path=tmp_path / "v.json", key_path=tmp_path / "k.key")
+    app = create_app(dummy, audit_logger=AuditLogger(tmp_path / "log.txt"), vault=vault)
+    client = TestClient(app)
+
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    assert "<h1>Settings</h1>" in resp.text
+
+    resp = client.post(
+        "/api/v1/settings",
+        data={
+            "openrouter_api_key": "o",
+            "mem0_url": "m",
+            "github_token": "g",
+            "slack_token": "s",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert vault.get_secret("openrouter_api_key") == "o"
+    assert vault.get_secret("mem0_url") == "m"
+    assert vault.get_secret("github_token") == "g"
+    assert vault.get_secret("slack_token") == "s"


### PR DESCRIPTION
## Summary
- extend FastAPI app with settings UI for tokens
- add HTML template for settings form
- allow configuring GitHub, Slack, OpenRouter and Mem0 keys
- include tests for new settings page
- add python-multipart dependency for form support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880cc2dbf90832da383b00e0e2a67bb