### PR TITLE
Implement human approval gate for planning workflow

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -547,6 +547,8 @@ def cmd_plan(manager: WorkflowManager, args) -> int:
     from ..planning.langgraph_workflow import LangGraphPlanningWorkflow
 
     issue = manager.issue_manager.get_issue(args.issue) or {}
+    issue["issue_id"] = str(args.issue)
+    issue.setdefault("repository", "default")
     platform = AutonomyPlatform()
     wf = platform.create_workflow(LangGraphPlanningWorkflow)
     result = wf.run(issue)

--- a/src/planning/langgraph_workflow.py
+++ b/src/planning/langgraph_workflow.py
@@ -35,6 +35,7 @@ class LangGraphPlanningWorkflow(PlanningWorkflow):
         graph.add_node("route", self.route)
         graph.add_node("assign", self.assign)
         graph.add_node("plan", self.plan)
+        graph.add_node("get_human_approval", self.get_human_approval)
         graph.add_node("approve", self.approve)
 
         graph.set_entry_point("analyze_issue")
@@ -43,7 +44,8 @@ class LangGraphPlanningWorkflow(PlanningWorkflow):
         graph.add_edge("decompose", "route")
         graph.add_edge("route", "assign")
         graph.add_edge("assign", "plan")
-        graph.add_edge("plan", "approve")
+        graph.add_edge("plan", "get_human_approval")
+        graph.add_edge("get_human_approval", "approve")
         graph.set_finish_point("approve")
 
         return graph.compile()

--- a/tests/test_cli_planning.py
+++ b/tests/test_cli_planning.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from src.cli.main import cmd_explain, cmd_memory, cmd_plan, cmd_tune
 from src.core.config import WorkflowConfig
 
@@ -29,7 +31,12 @@ class DummyManager:
 def test_cmd_plan(tmp_path: Path):
     manager = DummyManager(tmp_path)
     args = SimpleNamespace(issue=42)
+    from src.cli import main as cli_main
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(cli_main.click, "confirm", lambda *a, **k: True)
     assert cmd_plan(manager, args) == 0
+    monkeypatch.undo()
 
 
 def test_cmd_explain(tmp_path: Path, capsys):

--- a/tests/test_langgraph_planning.py
+++ b/tests/test_langgraph_planning.py
@@ -1,3 +1,6 @@
+import click
+import pytest
+
 from src.core.platform import AutonomyPlatform
 from src.planning.langgraph_workflow import LangGraphPlanningWorkflow
 
@@ -11,7 +14,10 @@ def test_langgraph_workflow_run():
         "created_at": "2025-07-10T00:00:00Z",
         "repository": "default",
     }
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
     result = wf.run(issue)
+    monkeypatch.undo()
     data = result.state.data
     assert result.success
     assert data["analysis"].startswith("LLM:")

--- a/tests/test_planning_workflow.py
+++ b/tests/test_planning_workflow.py
@@ -1,3 +1,6 @@
+import click
+import pytest
+
 from src.core.platform import AutonomyPlatform
 from src.planning.workflow import PlanningWorkflow
 
@@ -11,7 +14,10 @@ def test_planning_workflow_run():
         "created_at": "2025-07-10T00:00:00Z",
         "repository": "default",
     }
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: True)
     result = wf.run(issue)
+    monkeypatch.undo()
     data = result.state.data
     assert result.success
     assert data["analysis"].startswith("LLM:")


### PR DESCRIPTION
## Summary
- add CLI-driven approval step to planning workflow
- wire `get_human_approval` into LangGraph workflow
- include issue metadata when invoking plan command
- update tests to patch approval prompt

## Testing
- `flake8 tests/test_planning_workflow.py tests/test_langgraph_planning.py tests/test_cli_planning.py`


------
https://chatgpt.com/codex/tasks/task_e_6880cf978d18832db206c176f286535a