### PR TITLE
Implement planning CLI enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
           pytest -o addopts='' tests/test_planning_workflow.py -q
           pytest -o addopts='' tests/test_openrouter.py -q
           pytest -o addopts='' tests/test_cli_planning.py -q
+          pytest -o addopts='' tests/test_cli_extra_planning.py -q
           pytest -o addopts='' tests/test_mem0_client.py -q
           pytest -o addopts='' tests/test_tool_registry.py -q
 

--- a/src/github/issue_manager.py
+++ b/src/github/issue_manager.py
@@ -305,6 +305,24 @@ class IssueManager:
         except Exception:
             return False
 
+    def assign_issue(self, issue_number: int, assignees: List[str]) -> bool:
+        """Assign users to an issue."""
+        try:
+            response = requests.patch(
+                f"{self.base_url}/issues/{issue_number}",
+                headers=self.headers,
+                json={"assignees": assignees},
+            )
+            success = response.status_code == 200
+            if success and self.audit_logger:
+                self.audit_logger.log(
+                    "assign_issue",
+                    {"issue": issue_number, "assignees": assignees},
+                )
+            return success
+        except Exception:
+            return False
+
     def add_comment(self, issue_number: int, comment: str) -> bool:
         """Add a comment to an issue."""
         try:

--- a/tests/test_cli_extra_planning.py
+++ b/tests/test_cli_extra_planning.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.cli.main import cmd_assign, cmd_breakdown, cmd_rerank
+from src.core.config import WorkflowConfig
+
+
+class DummyIssueManager:
+    def __init__(self):
+        self.issues = {
+            42: {"title": "t", "labels": [], "created_at": "2025-07-10T00:00:00Z"}
+        }
+        self.assigned = None
+
+    def get_issue(self, num):
+        return self.issues.get(num)
+
+    def assign_issue(self, num, assignees):
+        self.assigned = (num, assignees)
+        return True
+
+
+class DummyManager:
+    def __init__(self, tmp_path: Path):
+        self.owner = "o"
+        self.repo = "r"
+        self.github_token = "t"
+        self.workspace_path = tmp_path
+        self.config = WorkflowConfig()
+        self.issue_manager = DummyIssueManager()
+        from src.audit.logger import AuditLogger
+
+        self.audit_logger = AuditLogger(tmp_path / "audit.log", use_git=True)
+
+
+def test_cmd_assign(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace(issue=42, to="bob")
+    assert cmd_assign(manager, args) == 0
+    assert manager.issue_manager.assigned == (42, ["bob"])
+
+
+def test_cmd_breakdown(monkeypatch, tmp_path: Path, capsys):
+    manager = DummyManager(tmp_path)
+    args = SimpleNamespace(issue=42)
+
+    class DummyWF:
+        def decompose(self, state):
+            state["tasks"] = ["a", "b"]
+            return state
+
+    class DummyPlatform:
+        def create_workflow(self, _):
+            return DummyWF()
+
+    monkeypatch.setattr("src.core.platform.AutonomyPlatform", DummyPlatform)
+    assert cmd_breakdown(manager, args) == 0
+    out = capsys.readouterr().out
+    assert "- a" in out and "- b" in out
+
+
+def test_cmd_rerank(monkeypatch, tmp_path: Path, capsys):
+    manager = DummyManager(tmp_path)
+
+    class DummyTM:
+        def __init__(self, *a, **kw):
+            from src.tasks.ranking import RankingEngine
+
+            self.ranking = RankingEngine()
+
+        def list_tasks(self):
+            return [
+                {
+                    "number": 1,
+                    "title": "t",
+                    "labels": [],
+                    "created_at": "2025-07-10T00:00:00Z",
+                }
+            ]
+
+    monkeypatch.setattr("src.tasks.task_manager.TaskManager", DummyTM)
+    args = SimpleNamespace()
+    assert cmd_rerank(manager, args) == 0
+    out = capsys.readouterr().out
+    assert "#1" in out


### PR DESCRIPTION
## Summary
- add command line interfaces for rerank, assign and breakdown
- add CLI tests for new commands
- support issue assignment in issue manager
- run new tests in CI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b36a47dc832d86e1678dd5ae309e