### PR TITLE
Implement CLI planning commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_audit_and_undo -q
           pytest -o addopts='' tests/test_pinned_items.py -q
           pytest -o addopts='' tests/test_cli_commands.py::test_cmd_pin_unpin_and_list -q
+          pytest -o addopts='' tests/test_cli_commands.py::test_cmd_next -q
+          pytest -o addopts='' tests/test_cli_commands.py::test_cmd_next_none -q
           pytest -o addopts='' tests/test_api_server.py -q
           pytest -o addopts='' tests/test_ranking_engine.py -q
           pytest -o addopts='' tests/test_planning_workflow.py -q

--- a/src/planning/workflow.py
+++ b/src/planning/workflow.py
@@ -172,6 +172,28 @@ class PlanningWorkflow(BaseWorkflow):
             }
         )
 
+    def rank_issues(
+        self, issues: list[dict[str, Any]], *, explain: bool = False
+    ) -> list[dict[str, Any]]:
+        """Return issues scored and sorted by priority."""
+        ranked: list[dict[str, Any]] = []
+        for issue in issues:
+            result = self.ranking.score_issue(issue, explain=explain)
+            if explain:
+                score, breakdown = result
+            else:
+                score = result
+                breakdown = None
+            if score == float("-inf"):
+                continue
+            item = issue.copy()
+            item["priority_score"] = score
+            if explain:
+                item["ranking_reason"] = breakdown
+            ranked.append(item)
+        ranked.sort(key=lambda x: x["priority_score"], reverse=True)
+        return ranked
+
     # Public API -------------------------------------------------------
     def run(self, issue: Dict[str, Any]) -> WorkflowResult:
         result = self.execute(issue)

--- a/tests/test_planning_workflow.py
+++ b/tests/test_planning_workflow.py
@@ -43,3 +43,23 @@ def test_security_routing_and_assignment():
     data = result.state.data
     assert data["requires_security_review"]
     assert data["assignee"] == "bob"
+
+
+def test_rank_issues():
+    platform = AutonomyPlatform()
+    wf = platform.create_workflow(PlanningWorkflow)
+    issues = [
+        {
+            "number": 1,
+            "labels": ["priority-low"],
+            "created_at": "2025-07-10T00:00:00Z",
+        },
+        {
+            "number": 2,
+            "labels": ["priority-high"],
+            "created_at": "2025-07-10T00:00:00Z",
+        },
+    ]
+    ranked = wf.rank_issues(issues)
+    assert [i["number"] for i in ranked] == [2, 1]
+    assert "priority_score" in ranked[0]


### PR DESCRIPTION
## Summary
- support ranking a list of issues via `PlanningWorkflow.rank_issues`
- compute `autonomy next` results using the Planning workflow
- test new planning ranking helper and update CLI command tests
- add new CLI tests to CI matrix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822f9b81f0832d939fdf242098c4dc