### PR TITLE
Implement basic metrics collection with Slack reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,4 +100,5 @@ jobs:
           pytest -o addopts='' tests/test_mem0_client.py -q
           pytest -o addopts='' tests/test_tool_registry.py -q
           pytest -o addopts='' tests/test_hierarchy_manager.py -q
+          pytest -o addopts='' tests/test_metrics.py -q
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -26,6 +26,7 @@ from .github.token_storage import (
     refresh_token_if_needed,
     validate_token,
 )
+from .metrics import MetricsCollector, MetricsStorage
 from .slack import (
     BacklogDoctorNotifier,
     MetricsDashboard,
@@ -91,6 +92,8 @@ __all__ = [
     "GitHubTools",
     "SlackTools",
     "MemoryTools",
+    "MetricsCollector",
+    "MetricsStorage",
     "verify_installation",
     "check_for_updates",
     "create_app",

--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -1,0 +1,4 @@
+from .collector import MetricsCollector
+from .storage import MetricsStorage
+
+__all__ = ["MetricsCollector", "MetricsStorage"]

--- a/src/metrics/collector.py
+++ b/src/metrics/collector.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from ..audit.logger import AuditLogger
+from ..slack.bot import SlackBot
+from .storage import MetricsStorage
+
+
+class MetricsCollector:
+    """Collect basic team metrics and generate Slack reports."""
+
+    def __init__(
+        self,
+        github_client: Any,
+        slack_client: SlackBot,
+        audit_logger: AuditLogger,
+        storage: MetricsStorage,
+    ) -> None:
+        self.github = github_client
+        self.slack = slack_client
+        self.audit = audit_logger
+        self.storage = storage
+
+    # ------------------------------------------------------------------
+    def collect_daily_metrics(self, repository: str) -> str:
+        """Collect metrics, store them and return a Slack report."""
+        metrics = {
+            "date": datetime.now().date(),
+            "repository": repository,
+            "time_to_task_avg": self.calculate_time_to_task(),
+            "approval_rate": self.calculate_approval_rate(),
+            "weekly_active_users": self.calculate_wau(),
+            "loc_per_assignee": self.calculate_loc_per_assignee(),
+            "sprint_completion_rate": self.calculate_sprint_completion(),
+            "open_issues_count": self.github.get_open_issues_count(repository),
+            "planning_commands_used": self.audit.count_command_usage("plan"),
+            "human_overrides_count": self.audit.count_human_overrides(),
+        }
+        self.storage.store_daily_metrics(repository, metrics)
+        return self.generate_slack_report(metrics)
+
+    def send_daily_report(self, repository: str, channel: str) -> bool:
+        """Collect metrics and post the report to Slack."""
+        report = self.collect_daily_metrics(repository)
+        return self.slack.post_message(channel, report)
+
+    # ------------------------------------------------------------------
+    def calculate_time_to_task(self) -> float:
+        func = getattr(self.github, "calculate_time_to_task", lambda: 0.0)
+        return float(func())
+
+    def calculate_wau(self) -> int:
+        func = getattr(self.audit, "weekly_active_users", lambda: 0)
+        return int(func())
+
+    def calculate_loc_per_assignee(self) -> int:
+        func = getattr(self.github, "calculate_loc_per_assignee", lambda: 0)
+        return int(func())
+
+    def calculate_sprint_completion(self) -> float:
+        func = getattr(self.github, "calculate_sprint_completion", lambda: 0.0)
+        return float(func())
+
+    def calculate_approval_rate(self) -> float:
+        approvals = self.audit.count_approvals(days=7)
+        total = self.audit.count_ai_recommendations(days=7)
+        return (approvals / total * 100) if total > 0 else 0.0
+
+    # ------------------------------------------------------------------
+    def generate_slack_report(self, metrics: Dict[str, Any]) -> str:
+        """Format metrics into a Slack-friendly message."""
+        return (
+            f"📊 **Daily Team Metrics** - {metrics['repository']}\n\n"
+            f"**🎯 Planning Efficiency**\n"
+            f"• Time to task assignment: {metrics['time_to_task_avg']:.1f} hours\n"
+            f"• AI approval rate: {metrics['approval_rate']:.1f}%\n"
+            f"• Sprint completion: {metrics['sprint_completion_rate']:.1f}%\n\n"
+            f"**👥 Team Activity**\n"
+            f"• Weekly active users: {metrics['weekly_active_users']} team members\n"
+            f"• Planning commands used: {metrics['planning_commands_used']} today\n"
+            f"• Human overrides: {metrics['human_overrides_count']} (learning opportunities)\n\n"
+            f"**📈 Development Velocity**\n"
+            f"• LOC per assignee: {metrics['loc_per_assignee']} avg\n"
+            f"• Open issues: {metrics['open_issues_count']}\n\n"
+            "💡 Use `/autonomy status` for detailed metrics"
+        )

--- a/src/metrics/storage.py
+++ b/src/metrics/storage.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from statistics import mean
+from typing import Dict
+
+
+class MetricsStorage:
+    """Store metrics data on disk."""
+
+    def __init__(self, storage_path: Path) -> None:
+        self.storage_path = Path(storage_path) / "metrics"
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+
+    def store_daily_metrics(self, repository: str, metrics: Dict) -> None:
+        """Persist metrics, filtering personal data."""
+        safe_metrics = self.filter_personal_data(metrics)
+        safe_repo = repository.replace("/", "-")
+        filename = f"{safe_repo}_{metrics['date']}.json"
+        with open(self.storage_path / filename, "w", encoding="utf-8") as f:
+            json.dump(safe_metrics, f, default=str)
+
+    def filter_personal_data(self, metrics: Dict) -> Dict:
+        """Remove personal identifiers while keeping useful aggregates."""
+        safe = metrics.copy()
+        if "loc_per_contributor" in safe:
+            safe["loc_per_assignee"] = mean(list(safe["loc_per_contributor"].values()))
+            del safe["loc_per_contributor"]
+        return safe

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,72 @@
+from datetime import date
+from pathlib import Path
+
+from src.metrics import MetricsCollector, MetricsStorage
+
+
+class DummyGitHub:
+    def get_open_issues_count(self, repo: str) -> int:
+        assert repo == "owner/repo"
+        return 5
+
+    def calculate_time_to_task(self) -> float:
+        return 4.2
+
+    def calculate_loc_per_assignee(self) -> int:
+        return 320
+
+    def calculate_sprint_completion(self) -> float:
+        return 75.0
+
+
+class DummyAudit:
+    def count_command_usage(self, cmd: str) -> int:
+        assert cmd == "plan"
+        return 3
+
+    def count_human_overrides(self) -> int:
+        return 1
+
+    def count_approvals(self, days: int = 7) -> int:
+        return 8
+
+    def count_ai_recommendations(self, days: int = 7) -> int:
+        return 10
+
+    def weekly_active_users(self) -> int:
+        return 5
+
+
+class DummySlack:
+    def __init__(self) -> None:
+        self.posted = []
+
+    def post_message(self, channel: str, text: str, blocks=None):
+        self.posted.append((channel, text))
+        return True
+
+
+def test_metrics_collection_and_storage(tmp_path: Path) -> None:
+    gh = DummyGitHub()
+    audit = DummyAudit()
+    slack = DummySlack()
+    storage = MetricsStorage(tmp_path)
+    collector = MetricsCollector(gh, slack, audit, storage)
+
+    report = collector.collect_daily_metrics("owner/repo")
+    assert "Daily Team Metrics" in report
+    files = list((tmp_path / "metrics").glob("*.json"))
+    assert files
+
+
+def test_storage_filters_personal_data(tmp_path: Path) -> None:
+    storage = MetricsStorage(tmp_path)
+    metrics = {
+        "date": date.today(),
+        "repository": "owner/repo",
+        "loc_per_contributor": {"a": 100, "b": 200},
+    }
+    storage.store_daily_metrics("owner/repo", metrics)
+    stored = next((tmp_path / "metrics").glob("*.json")).read_text()
+    assert "loc_per_contributor" not in stored
+    assert "loc_per_assignee" in stored


### PR DESCRIPTION
## Summary
- add `MetricsCollector` and `MetricsStorage` modules
- expose new metrics classes in package
- create tests for metrics collection
- run metrics tests in CI workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68824d4f9c5c832d9c48420107d74696