### PR TITLE
Finish roadmap gaps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,6 @@ repos:
         name: run tests
         entry: pytest
         language: system
+        env:
+          MEM0_TELEMETRY: "False"
         pass_filenames: false

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -503,7 +503,11 @@ def cmd_next(manager: WorkflowManager, args) -> int:
             continue
         filtered.append(issue)
 
-    platform = AutonomyPlatform()
+    platform = AutonomyPlatform(
+        github_token=manager.github_token,
+        owner=manager.owner,
+        repo=manager.repo,
+    )
     wf = platform.create_workflow(PlanningWorkflow)
     ranked = wf.rank_issues(filtered, explain=True)
     if not ranked:
@@ -571,6 +575,21 @@ def cmd_pin(manager: WorkflowManager, args) -> int:
 
     store = PinnedItemsStore()
     store.pin_item(f"{manager.owner}/{manager.repo}", str(args.issue))
+    from ..core.platform import AutonomyPlatform
+    from ..planning.workflow import PlanningWorkflow
+
+    platform = AutonomyPlatform(
+        github_token=manager.github_token,
+        owner=manager.owner,
+        repo=manager.repo,
+    )
+    wf = platform.create_workflow(PlanningWorkflow)
+    wf.learn_from_override(
+        str(args.issue),
+        {"pinned": False},
+        {"pinned": True},
+        repository="default",
+    )
     print(f"\N{CHECK MARK} Issue #{args.issue} pinned")
     return 0
 
@@ -581,6 +600,21 @@ def cmd_unpin(manager: WorkflowManager, args) -> int:
 
     store = PinnedItemsStore()
     store.unpin_item(f"{manager.owner}/{manager.repo}", str(args.issue))
+    from ..core.platform import AutonomyPlatform
+    from ..planning.workflow import PlanningWorkflow
+
+    platform = AutonomyPlatform(
+        github_token=manager.github_token,
+        owner=manager.owner,
+        repo=manager.repo,
+    )
+    wf = platform.create_workflow(PlanningWorkflow)
+    wf.learn_from_override(
+        str(args.issue),
+        {"pinned": True},
+        {"pinned": False},
+        repository="default",
+    )
     print(f"\N{CHECK MARK} Issue #{args.issue} unpinned")
     return 0
 
@@ -593,7 +627,11 @@ def cmd_plan(manager: WorkflowManager, args) -> int:
     issue = manager.issue_manager.get_issue(args.issue) or {}
     issue["issue_id"] = str(args.issue)
     issue.setdefault("repository", "default")
-    platform = AutonomyPlatform()
+    platform = AutonomyPlatform(
+        github_token=manager.github_token,
+        owner=manager.owner,
+        repo=manager.repo,
+    )
     wf = platform.create_workflow(LangGraphPlanningWorkflow)
     result = wf.run(issue)
     score = result.state.data.get("priority_score")
@@ -666,7 +704,11 @@ def cmd_breakdown(manager: WorkflowManager, args) -> int:
 
     issue = manager.issue_manager.get_issue(args.issue) or {}
     issue.setdefault("repository", "default")
-    platform = AutonomyPlatform()
+    platform = AutonomyPlatform(
+        github_token=manager.github_token,
+        owner=manager.owner,
+        repo=manager.repo,
+    )
     wf = platform.create_workflow(PlanningWorkflow)
     state = wf.decompose(issue)
     for t in state.get("tasks", []):
@@ -678,7 +720,11 @@ def cmd_memory(manager: WorkflowManager, args) -> int:
     """Display learned patterns."""
     from ..core.platform import AutonomyPlatform
 
-    platform = AutonomyPlatform()
+    platform = AutonomyPlatform(
+        github_token=manager.github_token,
+        owner=manager.owner,
+        repo=manager.repo,
+    )
     if not platform.memory.store:
         print("No patterns learned yet")
         return 0

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,8 +1,15 @@
 """Core tool registry and implementations."""
 
 from .github import GitHubTools
-from .memory import MemoryTools
 from .registry import ToolRegistry
 from .slack import SlackTools
 
 __all__ = ["ToolRegistry", "GitHubTools", "SlackTools", "MemoryTools"]
+
+
+def __getattr__(name):
+    if name == "MemoryTools":  # pragma: no cover - lazy import
+        from .memory import MemoryTools
+
+        return MemoryTools
+    raise AttributeError(name)

--- a/src/tools/github.py
+++ b/src/tools/github.py
@@ -20,6 +20,10 @@ class GitHubTools:
     def list_issues(self, state: str = "open") -> List[Dict[str, Any]]:
         return self.manager.list_issues(state=state)
 
+    def get_issue(self, issue_number: int) -> Optional[Dict[str, Any]]:
+        """Return issue data if found."""
+        return self.manager.get_issue(issue_number)
+
     def update_issue_labels(
         self,
         issue_number: int,
@@ -27,6 +31,27 @@ class GitHubTools:
         remove_labels: Optional[List[str]] = None,
     ) -> bool:
         return self.manager.update_issue_labels(issue_number, add_labels, remove_labels)
+
+    def update_issue(
+        self,
+        issue_number: int,
+        *,
+        title: Optional[str] = None,
+        body: Optional[str] = None,
+        labels: Optional[List[str]] = None,
+    ) -> bool:
+        """Update basic issue fields."""
+        return self.manager.update_issue(
+            issue_number, title=title, body=body, labels=labels
+        )
+
+    def update_issue_state(self, issue_number: int, state: str) -> bool:
+        """Open or close an issue."""
+        return self.manager.update_issue_state(issue_number, state)
+
+    def assign_issue(self, issue_number: int, assignees: List[str]) -> bool:
+        """Assign users to an issue."""
+        return self.manager.assign_issue(issue_number, assignees)
 
     def add_comment(self, issue_number: int, comment: str) -> bool:
         return self.manager.add_comment(issue_number, comment)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -159,6 +159,9 @@ def test_cmd_next(monkeypatch, tmp_path: Path):
             ]
 
     class DummyPlatform:
+        def __init__(self, *_, **__):
+            pass
+
         def create_workflow(self, _):
             return DummyWF()
 
@@ -194,6 +197,9 @@ def test_cmd_next_none(monkeypatch, tmp_path: Path, capsys):
             return []
 
     class DummyPlatform:
+        def __init__(self, *_, **__):
+            pass
+
         def create_workflow(self, _):
             return DummyWF()
 

--- a/tests/test_cli_extra_planning.py
+++ b/tests/test_cli_extra_planning.py
@@ -50,6 +50,9 @@ def test_cmd_breakdown(monkeypatch, tmp_path: Path, capsys):
             return state
 
     class DummyPlatform:
+        def __init__(self, *_, **__):
+            pass
+
         def create_workflow(self, _):
             return DummyWF()
 

--- a/tests/test_cli_planning.py
+++ b/tests/test_cli_planning.py
@@ -64,7 +64,7 @@ def test_cmd_memory(tmp_path: Path, capsys, monkeypatch):
             self.store = {"default": {"k": "v"}}
 
     class DummyPlatform:
-        def __init__(self):
+        def __init__(self, *_, **__):
             self.memory = DummyMem()
 
     monkeypatch.setattr("src.core.platform.AutonomyPlatform", DummyPlatform)


### PR DESCRIPTION
## Summary
- integrate real GitHub and Slack tools in the platform
- allow remote Mem0 client via MEM0_API_KEY
- record pinned override events when pinning/unpinning issues
- pass repository credentials to workflows
- lazily load MemoryTools to avoid circular import errors
- expose more GitHub operations through GitHubTools
- disable Mem0 telemetry during tests

## Testing
- `pre-commit run --files src/core/platform.py src/cli/main.py src/tools/__init__.py src/tools/github.py .pre-commit-config.yaml` *(fails: blocked POSTHOG)*

------
https://chatgpt.com/codex/tasks/task_e_688252408314832d9bb4322f2a2cff09