### PR TITLE
Implement nightly backlog doctor service

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -39,6 +39,7 @@ from .slack import (
     verify_slack_signature,
 )
 from .tasks.backlog_doctor import BacklogDoctor
+from .tasks.nightly_service import NightlyDoctorService
 from .tasks.task_manager import TaskManager
 from .tools import GitHubTools, MemoryTools, SlackTools, ToolRegistry
 
@@ -76,6 +77,7 @@ __all__ = [
     # Planning
     "TaskManager",
     "BacklogDoctor",
+    "NightlyDoctorService",
     "SecretVault",
     # Version info
     "__version__",

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -1,4 +1,5 @@
 from .hierarchy_manager import HierarchyManager, IssueNode
+from .nightly_service import NightlyDoctorService
 from .ranking import RankingConfig, RankingEngine
 from .task_manager import TaskManager
 
@@ -8,4 +9,5 @@ __all__ = [
     "IssueNode",
     "RankingConfig",
     "RankingEngine",
+    "NightlyDoctorService",
 ]

--- a/src/tasks/nightly_service.py
+++ b/src/tasks/nightly_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from ..github.issue_manager import IssueManager
+from ..slack.bot import SlackBot
+from ..slack.notifications import NotificationScheduler
+from .backlog_doctor import BacklogDoctor
+
+
+class NightlyDoctorService:
+    """Run BacklogDoctor on multiple repositories nightly."""
+
+    def __init__(
+        self,
+        repo_channels: Dict[str, str],
+        github_token: str,
+        slack_token: str,
+        run_time: str = "02:00",
+    ) -> None:
+        self.scheduler = NotificationScheduler(SlackBot(slack_token))
+        for repo, channel in repo_channels.items():
+            owner, name = repo.split("/")
+            manager = IssueManager(github_token, owner, name)
+            doctor = BacklogDoctor(manager, self.scheduler.slack_client)
+            self.scheduler.schedule_daily(
+                name=repo,
+                time=run_time,
+                func=lambda c=channel, d=doctor: d.run_nightly_diagnosis(channel=c),
+                channel=channel,
+            )
+
+    def run(self, forever: bool = False) -> None:
+        """Execute scheduled runs."""
+        self.scheduler.run_scheduler(block=forever)


### PR DESCRIPTION
## Summary
- add `NightlyDoctorService` for nightly checks
- integrate nightly command into CLI
- extend notification scheduler for repeated execution
- update tests for new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688326787404832d9cb820767f51a7fd