### PR TITLE
Complete metrics feature

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -39,6 +39,7 @@ from .slack import (
     verify_slack_signature,
 )
 from .tasks.backlog_doctor import BacklogDoctor
+from .tasks.metrics_service import DailyMetricsService
 from .tasks.nightly_service import NightlyDoctorService
 from .tasks.task_manager import TaskManager
 from .tools import GitHubTools, MemoryTools, SlackTools, ToolRegistry
@@ -78,6 +79,7 @@ __all__ = [
     "TaskManager",
     "BacklogDoctor",
     "NightlyDoctorService",
+    "DailyMetricsService",
     "SecretVault",
     # Version info
     "__version__",

--- a/src/metrics/collector.py
+++ b/src/metrics/collector.py
@@ -52,7 +52,9 @@ class MetricsCollector:
         return float(func())
 
     def calculate_wau(self) -> int:
-        func = getattr(self.audit, "weekly_active_users", lambda: 0)
+        if hasattr(self.audit, "weekly_active_users"):
+            return int(self.audit.weekly_active_users())
+        func = getattr(self.github, "weekly_active_users", lambda: 0)
         return int(func())
 
     def calculate_loc_per_assignee(self) -> int:

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -1,4 +1,5 @@
 from .hierarchy_manager import HierarchyManager, IssueNode
+from .metrics_service import DailyMetricsService
 from .nightly_service import NightlyDoctorService
 from .ranking import RankingConfig, RankingEngine
 from .task_manager import TaskManager
@@ -10,4 +11,5 @@ __all__ = [
     "RankingConfig",
     "RankingEngine",
     "NightlyDoctorService",
+    "DailyMetricsService",
 ]

--- a/src/tasks/metrics_service.py
+++ b/src/tasks/metrics_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from ..audit.logger import AuditLogger
+from ..github.issue_manager import IssueManager
+from ..metrics import MetricsCollector, MetricsStorage
+from ..slack.bot import SlackBot
+from ..slack.notifications import NotificationScheduler
+
+
+class DailyMetricsService:
+    """Schedule daily metrics collection and Slack reporting."""
+
+    def __init__(
+        self,
+        repo_channels: Dict[str, str],
+        github_token: str,
+        slack_token: str,
+        run_time: str = "09:00",
+        *,
+        storage_path: Path | str = Path("metrics"),
+        log_path: Path | str = Path("audit.log"),
+    ) -> None:
+        self.scheduler = NotificationScheduler(SlackBot(slack_token))
+        for repo, channel in repo_channels.items():
+            owner, name = repo.split("/")
+            manager = IssueManager(github_token, owner, name)
+            audit = AuditLogger(Path(log_path))
+            storage = MetricsStorage(Path(storage_path))
+            collector = MetricsCollector(
+                manager, self.scheduler.slack_client, audit, storage
+            )
+            self.scheduler.schedule_daily(
+                name=repo,
+                time=run_time,
+                func=lambda ch=channel, c=collector, r=repo: c.send_daily_report(r, ch),
+                channel=channel,
+            )
+
+    def run(self, forever: bool = False) -> None:
+        """Execute scheduled metrics reports."""
+        self.scheduler.run_scheduler(block=forever)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -8,6 +8,7 @@ from src.cli.main import (
     cmd_doctor_nightly,
     cmd_init,
     cmd_list,
+    cmd_metrics_daily,
     cmd_next,
     cmd_pin,
     cmd_process,
@@ -338,6 +339,28 @@ def test_cmd_doctor_nightly(monkeypatch, tmp_path: Path):
         forever=False,
     )
     assert cmd_doctor_nightly(manager, SecretVault(), args) == 0
+
+
+def test_cmd_metrics_daily(monkeypatch, tmp_path: Path):
+    manager = DummyManager(tmp_path)
+
+    class DummyService:
+        def __init__(self, mapping, token, slack_token, run_time="09:00", **kw):
+            self.called = False
+
+        def run(self, forever=False):
+            self.called = True
+
+    monkeypatch.setattr("src.tasks.metrics_service.DailyMetricsService", DummyService)
+
+    args = SimpleNamespace(
+        repos=["owner/repo"],
+        channel="#m",
+        time="09:00",
+        slack_token="t",
+        forever=False,
+    )
+    assert cmd_metrics_daily(manager, SecretVault(), args) == 0
 
 
 def test_cmd_audit_and_undo(tmp_path: Path):

--- a/tests/test_github_metrics.py
+++ b/tests/test_github_metrics.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+
+import pytest
+
+from src.github.issue_manager import IssueManager
+
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self):
+        return self._data
+
+
+def test_issue_manager_metrics(monkeypatch):
+    events_called = []
+
+    def dummy_get(url, headers=None, params=None):
+        if url.endswith("/issues") and params.get("state") in {"open", "all"}:
+            return DummyResponse(
+                [{"number": 1, "created_at": datetime.utcnow().isoformat()}]
+            )
+        if url.endswith("/issues") and params.get("since"):
+            return DummyResponse(
+                [
+                    {
+                        "user": {"login": "a"},
+                        "number": 1,
+                        "created_at": datetime.utcnow().isoformat(),
+                    }
+                ]
+            )
+        if url.endswith("/milestones"):
+            return DummyResponse([{"closed_issues": 3, "open_issues": 1}])
+        if "/events" in url:
+            events_called.append(url)
+            return DummyResponse(
+                [{"event": "assigned", "created_at": datetime.utcnow().isoformat()}]
+            )
+        return DummyResponse([])
+
+    monkeypatch.setattr("requests.get", dummy_get)
+
+    mgr = IssueManager("t", "o", "r")
+    assert mgr.get_open_issues_count("o/r") == 1
+    assert mgr.weekly_active_users() >= 0
+    assert mgr.calculate_sprint_completion() == pytest.approx(75.0)
+    assert mgr.calculate_time_to_task() >= 0
+    assert events_called


### PR DESCRIPTION
## Summary
- add daily metrics service
- compute sprint completion and active users in IssueManager
- extend metrics collector and CLI for scheduled reporting
- add tests for metrics service and issue manager metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68832d86ce88832dbd95a08a0330edbc