### PR TITLE
Add release workflow and update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, testing]
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine release type
+        id: rtype
+        run: |
+          git fetch origin main testing
+          if git merge-base --is-ancestor $GITHUB_SHA origin/testing; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          prerelease: ${{ steps.rtype.outputs.prerelease }}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ We welcome contributions from developers interested in AI-human collaboration an
 
 ---
 
+### Release Strategy
+
+Stable releases are tagged from the `main` branch. Testing releases use commits from the `testing` branch and are published as pre-releases. Development work should occur on feature branches that merge into `testing` before stabilizing in `main`.
+
+
 ## 📄 License
 
 This project is licensed under the GNU GPLv3 or later - see the [LICENSE](LICENSE) file for details.

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -36,3 +36,7 @@ pre-commit install
   pytest
   ```
 The test configuration enforces a minimum of 80% coverage.
+## Branching and Releases
+
+Create feature branches from `testing` for development. The `testing` branch is used to publish pre-release versions. Stable releases are tagged from `main`. When a feature is ready, merge it into `testing`; after validation it can be promoted to `main`.
+

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -54,3 +54,8 @@ Issues progress through these states:
 - All tests must pass
 - No direct pushes allowed
 - Human approval required for merge
+
+## Release Process
+
+Stable releases are created from the `main` branch. A testing branch named `testing` is used for pre-release builds. Feature development should occur on separate branches that merge into `testing` before being promoted to `main`. Tags on `main` trigger stable releases, while tags on `testing` create pre-releases.
+


### PR DESCRIPTION
## Summary
- document release strategy in README
- clarify branch usage in development docs
- add release guidelines to workflow doc
- update CI to run on main and testing branches
- add GitHub workflow to create releases from version tags

## Testing
- `pytest -q` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68828af53520832d8ba18d70fb4a000c