### PR TITLE
Add community docs and examples

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment for our community include:
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <opensource@example.com>. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+**Community Impact**: A violation through a single incident or series of actions.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing Guide
+
+Thank you for considering contributing to Autonomy! The following guidelines help keep development smooth for everyone.
+
+## Getting Started
+1. Fork the repository and create a new branch for your change.
+2. Install dependencies with `pip install -e .[dev]` and run `pre-commit install`.
+3. Make sure tests run with `pytest` before submitting a pull request.
+
+## Pull Requests
+* Provide a clear description of your change and why it is useful.
+* Update documentation and tests as appropriate.
+* Ensure `pre-commit` hooks pass locally.
+* After review, one of the maintainers will merge your change.
+
+## Community
+We follow the [Code of Conduct](CODE_OF_CONDUCT.md). Be kind and respectful in all interactions.
+
+## Questions
+Feel free to open an issue or discussion if you have any questions about using or contributing to the project.

--- a/docs/TECH.md
+++ b/docs/TECH.md
@@ -550,7 +550,37 @@ class PlanningWorkflow(BaseWorkflow):
             message=f"New plan ready for review: {pr.url}"
         )
         
-        return {"pr_created": pr.url, **state}
+return {"pr_created": pr.url, **state}
+```
+
+### Authentication Flow
+```mermaid
+sequenceDiagram
+    participant U as CLI User
+    participant CLI as CLI App
+    participant GH as GitHub OAuth
+    participant S as SecureTokenStorage
+    U->>CLI: auth login
+    CLI->>GH: start device flow
+    GH-->>CLI: device_code,user_code
+    CLI->>U: show verification URL
+    U->>GH: authorize device
+    CLI->>GH: poll for token
+    GH-->>CLI: access_token
+    CLI->>S: store token
+    CLI-->>U: authenticated
+```
+
+### Ranking Engine Loop
+```mermaid
+sequenceDiagram
+    participant TM as TaskManager
+    participant RE as RankingEngine
+    participant CFG as YAML Config
+    TM->>RE: score_issue(issue)
+    RE->>CFG: load weights
+    RE-->>TM: priority score
+    TM->>TM: sort issues by score
 ```
 
 ---

--- a/examples/agent.yml
+++ b/examples/agent.yml
@@ -1,0 +1,11 @@
+# Example planning agent configuration
+agent:
+  name: example-planner
+  workflow: planning
+  model: openai/gpt-4o
+  description: Basic planning agent that analyzes issues and creates tasks.
+github:
+  repository: my-org/my-repo
+memory:
+  provider: mem0
+  workspace: my-org/my-repo

--- a/examples/board_cache.json
+++ b/examples/board_cache.json
@@ -1,0 +1,6 @@
+{
+  "Priority": "PV2F_priority",
+  "Pinned": "PV2F_pinned",
+  "Sprint": "PV2F_sprint",
+  "Track": "PV2F_track"
+}


### PR DESCRIPTION
## Summary
- document how to contribute
- add project code of conduct
- include example configuration files
- document auth and ranking diagrams in TECH.md

## Testing
- `pytest -q` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68834ac154f4832d98be599a40c1bcff