### PR TITLE
Implement error handling framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,4 +102,5 @@ jobs:
           pytest -o addopts='' tests/test_hierarchy_manager.py -q
           pytest -o addopts='' tests/test_metrics.py -q
           pytest -o addopts='' tests/test_release_scripts.py -q
+          pytest -o addopts='' tests/test_error_handling.py -q
 

--- a/src/core/errors.py
+++ b/src/core/errors.py
@@ -1,0 +1,53 @@
+"""Custom error types and handling utilities."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable
+
+
+class AutonomyError(Exception):
+    """Base exception with optional suggestion and error code."""
+
+    def __init__(
+        self, message: str, suggestion: str | None = None, error_code: str | None = None
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.suggestion = suggestion
+        self.error_code = error_code
+
+
+class GitHubAPIError(AutonomyError):
+    """GitHub API specific errors."""
+
+
+class ConfigurationError(AutonomyError):
+    """Configuration related errors."""
+
+
+def handle_errors(func: Callable[..., int]) -> Callable[..., int]:
+    """Decorator to display helpful messages for common errors."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> int:
+        try:
+            return func(*args, **kwargs)
+        except GitHubAPIError as e:
+            print(f"❌ GitHub API Error: {e.message}")
+            if e.suggestion:
+                print(f"💡 Suggestion: {e.suggestion}")
+            return 1
+        except AutonomyError as e:
+            print(f"❌ {e.message}")
+            if e.suggestion:
+                print(f"💡 Suggestion: {e.suggestion}")
+            return 1
+        except Exception as e:  # pragma: no cover - fallback
+            print(f"❌ Unexpected error: {e}")
+            print(
+                "🐛 Please report this at: https://github.com/mehulbhardwaj/autonomy/issues"
+            )
+            return 1
+
+    return wrapper

--- a/src/github/__init__.py
+++ b/src/github/__init__.py
@@ -1,6 +1,7 @@
 """GitHub integration utilities."""
 
 from .board_manager import BoardManager, GraphQLClient
+from .client import ResilientGitHubClient
 from .device_flow import DeviceFlowResponse, GitHubDeviceFlow, OAuthError
 from .issue_manager import IssueManager
 from .pat_scopes import (
@@ -23,4 +24,5 @@ __all__ = [
     "SecureTokenStorage",
     "validate_token",
     "refresh_token_if_needed",
+    "ResilientGitHubClient",
 ]

--- a/src/github/client.py
+++ b/src/github/client.py
@@ -1,0 +1,31 @@
+"""HTTP client with retry and backoff for GitHub requests."""
+
+from __future__ import annotations
+
+import backoff
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+class ResilientGitHubClient:
+    """Simple HTTP client with retries and exponential backoff."""
+
+    def __init__(self) -> None:
+        self.session = requests.Session()
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
+
+    @backoff.on_exception(
+        backoff.expo, requests.exceptions.RequestException, max_tries=3
+    )
+    def make_request(
+        self, method: str, url: str, **kwargs
+    ):  # pragma: no cover - simple wrapper
+        return self.session.request(method, url, **kwargs)

--- a/tests/test_board_manager.py
+++ b/tests/test_board_manager.py
@@ -14,7 +14,7 @@ class DummyResponse:
 def test_init_board_creates_fields(tmp_path, monkeypatch):
     calls = []
 
-    def dummy_post(url, headers=None, json=None, timeout=10):
+    def dummy_post(self, method, url, headers=None, json=None, timeout=10):
         query = json["query"]
         calls.append(query)
         if "RepoProjects" in query:
@@ -45,7 +45,9 @@ def test_init_board_creates_fields(tmp_path, monkeypatch):
             )
         return DummyResponse({"data": {}})
 
-    monkeypatch.setattr("requests.post", dummy_post)
+    monkeypatch.setattr(
+        "src.github.client.ResilientGitHubClient.make_request", dummy_post
+    )
     cache = tmp_path / "cache.json"
     bm = BoardManager("t", "o", "r", cache_path=cache)
     result = bm.init_board()
@@ -59,7 +61,7 @@ def test_init_board_creates_fields(tmp_path, monkeypatch):
 def test_init_board_uses_existing(tmp_path, monkeypatch):
     calls = []
 
-    def dummy_post(url, headers=None, json=None, timeout=10):
+    def dummy_post(self, method, url, headers=None, json=None, timeout=10):
         query = json["query"]
         calls.append(query)
         if "RepoProjects" in query:
@@ -95,7 +97,9 @@ def test_init_board_uses_existing(tmp_path, monkeypatch):
             raise AssertionError("Should not add options for existing fields")
         return DummyResponse({"data": {}})
 
-    monkeypatch.setattr("requests.post", dummy_post)
+    monkeypatch.setattr(
+        "src.github.client.ResilientGitHubClient.make_request", dummy_post
+    )
     cache = tmp_path / "cache.json"
     bm = BoardManager("t", "o", "r", cache_path=cache)
     result = bm.init_board()
@@ -108,7 +112,7 @@ def test_default_cache_path(monkeypatch, tmp_path):
 
     calls = []
 
-    def dummy_post(url, headers=None, json=None, timeout=10):
+    def dummy_post(self, method, url, headers=None, json=None, timeout=10):
         query = json["query"]
         calls.append(query)
         if "RepoProjects" in query:
@@ -127,7 +131,9 @@ def test_default_cache_path(monkeypatch, tmp_path):
             )
         return DummyResponse({"data": {}})
 
-    monkeypatch.setattr("requests.post", dummy_post)
+    monkeypatch.setattr(
+        "src.github.client.ResilientGitHubClient.make_request", dummy_post
+    )
     bm = BoardManager("t", "o", "r")
     bm.init_board()
     default_path = tmp_path / ".autonomy" / "field_cache.json"

--- a/tests/test_board_priority.py
+++ b/tests/test_board_priority.py
@@ -12,7 +12,7 @@ class DummyResponse:
 
 
 def _mock_post_factory(items, record):
-    def dummy_post(url, headers=None, json=None, timeout=10):
+    def dummy_post(self, method, url, headers=None, json=None, timeout=10):
         query = json["query"]
         record.append(query)
         if "RepoProjects" in query:
@@ -80,7 +80,10 @@ def test_rank_items(monkeypatch):
         },
     ]
     record = []
-    monkeypatch.setattr("requests.post", _mock_post_factory(items, record))
+    monkeypatch.setattr(
+        "src.github.client.ResilientGitHubClient.make_request",
+        _mock_post_factory(items, record),
+    )
     bm = BoardManager("t", "o", "r")
     ranked = bm.rank_items()
     assert [i["number"] for i in ranked] == [1, 2]
@@ -121,7 +124,10 @@ def test_reorder_items(monkeypatch):
         },
     ]
     record = []
-    monkeypatch.setattr("requests.post", _mock_post_factory(items, record))
+    monkeypatch.setattr(
+        "src.github.client.ResilientGitHubClient.make_request",
+        _mock_post_factory(items, record),
+    )
     bm = BoardManager("t", "o", "r")
     bm.reorder_items()
     # ensure mutation called to move it2 after it1, but not for pinned item it1

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,29 @@
+from src.core.errors import GitHubAPIError, handle_errors
+from src.github.client import ResilientGitHubClient
+
+
+def test_handle_errors_decorator(capsys):
+    @handle_errors
+    def boom():
+        raise GitHubAPIError("fail", suggestion="check token")
+
+    assert boom() == 1
+    out = capsys.readouterr().out
+    assert "GitHub API Error" in out
+    assert "check token" in out
+
+
+def test_resilient_github_client(monkeypatch):
+    client = ResilientGitHubClient()
+    called = {}
+
+    def fake_request(method, url, **kwargs):
+        called["method"] = method
+        called["url"] = url
+        return "ok"
+
+    monkeypatch.setattr(client.session, "request", fake_request)
+    result = client.make_request("GET", "http://example.com")
+    assert result == "ok"
+    assert called["method"] == "GET"
+    assert "example.com" in called["url"]


### PR DESCRIPTION
## Summary
- add `AutonomyError` hierarchy and `handle_errors` decorator
- implement resilient GitHub HTTP client
- integrate new error handling with CLI commands
- retry GraphQL requests via new client
- test new error utilities
- hook new tests into CI pipeline

## Testing
- `pre-commit run --files src/core/errors.py src/github/client.py src/github/board_manager.py src/github/__init__.py src/cli/main.py tests/test_error_handling.py tests/test_board_manager.py tests/test_board_priority.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b5c26620832d8ffd03cb742e1bb5