### PR TITLE
Add hierarchy sync config and debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ autonomy board rank
 
 # Reorder items
 autonomy board reorder
+
+# Sync hierarchy
+autonomy hierarchy-sync
 ```
 
 ---

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -42,6 +42,12 @@ def create_app(
 
     task_manager.ranking = RankingEngine()
     task_manager.project_id = f"{issue_manager.owner}/{issue_manager.repo}"
+    from ..core.config import WorkflowConfig
+
+    task_manager.config = WorkflowConfig()
+    task_manager.sync_cooldown = task_manager.config.hierarchy_sync_cooldown
+    task_manager._last_sync = 0.0
+    task_manager.audit_logger = audit_logger
     backlog_doctor = BacklogDoctor(issue_manager)
     audit_logger = audit_logger or AuditLogger(Path("audit.log"))
     undo_manager = UndoManager(issue_manager, audit_logger)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -56,6 +56,10 @@ class WorkflowConfig:
     # Board configuration
     board_cache_path: str = "~/.autonomy/field_cache.json"
 
+    # Hierarchy management
+    hierarchy_orphan_threshold: int = 3
+    hierarchy_sync_cooldown: int = 60
+
     # ------------------------------------------------------------------
     @classmethod
     def from_yaml(cls, path: Path) -> "WorkflowConfig":
@@ -113,5 +117,11 @@ class WorkflowConfig:
             raise ValueError(
                 "autonomy_level must be one of: supervised, semi-autonomous, autonomous"
             )
+
+        if self.hierarchy_orphan_threshold <= 0:
+            raise ValueError("hierarchy_orphan_threshold must be positive")
+
+        if self.hierarchy_sync_cooldown <= 0:
+            raise ValueError("hierarchy_sync_cooldown must be positive")
 
         return True

--- a/src/github/issue_manager.py
+++ b/src/github/issue_manager.py
@@ -351,7 +351,8 @@ class IssueManager:
         title: Optional[str] = None,
         body: Optional[str] = None,
         labels: Optional[List[str]] = None,
-    ) -> bool:
+        return_response: bool = False,
+    ) -> bool | requests.Response:
         """Update basic fields on an issue."""
         payload: Dict[str, Any] = {}
         if title is not None:
@@ -375,7 +376,7 @@ class IssueManager:
                     "update_issue",
                     {k: payload[k] for k in payload.keys()},
                 )
-            return success
+            return response if return_response else success
         except Exception:
             return False
 

--- a/tests/test_autonomy_core.py
+++ b/tests/test_autonomy_core.py
@@ -25,6 +25,8 @@ class TestWorkflowConfig:
         assert config.test_coverage_target == 0.75
         assert config.autonomy_level == "supervised"
         assert config.board_cache_path.endswith("field_cache.json")
+        assert config.hierarchy_orphan_threshold == 3
+        assert config.hierarchy_sync_cooldown == 60
 
     def test_custom_config(self):
         """Test custom configuration values."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -469,3 +469,20 @@ def test_cmd_metrics_export(tmp_path: Path, capsys):
     assert main.cmd_metrics_export(manager, args) == 0
     out = capsys.readouterr().out
     assert "autonomy_time_to_task_avg" in out
+
+
+def test_cmd_hierarchy_sync(monkeypatch, tmp_path: Path):
+    manager = DummyManager(tmp_path)
+
+    class DummyHM:
+        def __init__(self, im, orphan_threshold=3):
+            assert orphan_threshold == 3
+
+        def maintain_hierarchy(self):
+            return {"created": [1], "orphans": [2]}
+
+    monkeypatch.setattr("src.tasks.hierarchy_manager.HierarchyManager", DummyHM)
+    args = SimpleNamespace(
+        dry_run=False, force=False, verbose=False, orphan_threshold=None
+    )
+    assert main.cmd_hierarchy_sync(manager, args) == 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 from pathlib import Path
 
@@ -17,6 +18,9 @@ class DummyGitHub:
 
     def calculate_sprint_completion(self) -> float:
         return 75.0
+
+    def list_issues(self, state="open"):
+        return [{"number": 1, "labels": ["task"], "body": ""}]
 
 
 class DummyAudit:
@@ -57,6 +61,8 @@ def test_metrics_collection_and_storage(tmp_path: Path) -> None:
     assert "Daily Team Metrics" in report
     files = list((tmp_path / "metrics").glob("*.json"))
     assert files
+    data = json.loads(files[0].read_text())
+    assert "orphan_issues_count" in data
 
 
 def test_storage_filters_personal_data(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add hierarchy-sync CLI options with orphan threshold
- collect orphan counts in metrics and config
- throttle automatic hierarchy sync via TaskManager
- expose settings in `WorkflowConfig`
- update tests for new features

## Testing
- `pre-commit run --files tests/test_task_manager.py src/tasks/task_manager.py src/cli/main.py tests/test_cli_commands.py tests/test_autonomy_core.py src/api/server.py src/core/config.py README.md`


------
https://chatgpt.com/codex/tasks/task_e_6884c8b455b0832dac83ae8e5fcd5fb9