### PR TITLE
Implement undo system enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Copilot integration
 - Playwright integration for UI testing
 - Advanced agent customization
+- Complete undo system with Slack `/autonomy undo` command
 
 ## [0.1.1] - 2025-07-16
 ### Added

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -50,7 +50,11 @@ def create_app(
     task_manager.audit_logger = audit_logger
     backlog_doctor = BacklogDoctor(issue_manager)
     audit_logger = audit_logger or AuditLogger(Path("audit.log"))
-    undo_manager = UndoManager(issue_manager, audit_logger)
+    undo_manager = UndoManager(
+        issue_manager,
+        audit_logger,
+        commit_window=getattr(task_manager.config, "commit_window", 5),
+    )
     vault = vault or SecretVault()
 
     app = FastAPI(title="Autonomy API", version="1.0")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1172,7 +1172,11 @@ def cmd_undo(manager: WorkflowManager, args) -> int:
     """Undo a previously logged operation."""
     from ..audit.undo import UndoManager
 
-    um = UndoManager(manager.issue_manager, manager.audit_logger)
+    um = UndoManager(
+        manager.issue_manager,
+        manager.audit_logger,
+        commit_window=getattr(manager.config, "commit_window", 5),
+    )
     if args.last:
         result = um.undo_last()
         if not result:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -56,6 +56,9 @@ class WorkflowConfig:
     # Board configuration
     board_cache_path: str = "~/.autonomy/field_cache.json"
 
+    # Undo configuration
+    commit_window: int = 5
+
     # Hierarchy management
     hierarchy_orphan_threshold: int = 3
     hierarchy_sync_cooldown: int = 60
@@ -123,5 +126,8 @@ class WorkflowConfig:
 
         if self.hierarchy_sync_cooldown <= 0:
             raise ValueError("hierarchy_sync_cooldown must be positive")
+
+        if self.commit_window <= 0:
+            raise ValueError("commit_window must be positive")
 
         return True

--- a/tests/test_slack_commands.py
+++ b/tests/test_slack_commands.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from src.core.secret_vault import SecretVault
 from src.slack.commands import SlashCommandHandler
 from src.slack.mapping import SlackGitHubMapper
@@ -6,6 +8,7 @@ from src.slack.mapping import SlackGitHubMapper
 class DummyTM:
     def __init__(self):
         self.updated = None
+        self.labels = None
 
     def get_next_task(self, assignee=None, team=None):
         assert assignee == "gh"
@@ -21,6 +24,11 @@ class DummyTM:
             {"number": 1, "title": "t1", "labels": ["in-progress"]},
             {"number": 2, "title": "t2", "labels": []},
         ]
+
+    # methods for UndoManager
+    def update_issue_labels(self, issue_number, add_labels=None, remove_labels=None):
+        self.labels = (issue_number, add_labels, remove_labels)
+        return True
 
 
 def test_slack_github_mapper(tmp_path):
@@ -65,3 +73,19 @@ def test_slash_status(tmp_path):
     resp = handler.handle_command("/autonomy status", {"user_id": "U"})
     assert resp["response_type"] == "ephemeral"
     assert resp["blocks"][1]["type"] == "fields"
+
+
+def test_slash_undo(tmp_path: Path):
+    from src.audit.logger import AuditLogger
+
+    tm = DummyTM()
+    tm.issue_manager = tm  # type: ignore[attr-defined]
+    logger = AuditLogger(tmp_path / "audit.log")
+    tm.audit_logger = logger
+
+    h = logger.log(
+        "update_labels", {"issue": 1, "add_labels": ["a"], "remove_labels": None}
+    )
+    handler = SlashCommandHandler(tm)
+    resp = handler.handle_command("/autonomy undo", {"text": h})
+    assert "Undo" in resp["text"]


### PR DESCRIPTION
## Summary
- add `commit_window` to workflow config
- track `diff_hash` in audit logs
- expand UndoManager with commit window and diff hash lookups
- expose `/autonomy undo` Slack command
- add unit tests for undo enhancements

## Testing
- `flake8 --max-line-length=120 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688514bbab58832dad8dd3d31a507a0f