### PR TITLE
Implement shadow branch PR creation

### DIFF
--- a/src/audit/undo.py
+++ b/src/audit/undo.py
@@ -59,3 +59,62 @@ class UndoManager:
                 note = f"Undo: delete previous comment -> {comment}"
                 return self.issue_manager.add_comment(issue, note)
         return False
+
+    # ------------------------------------------------------------------
+    def create_shadow_branch_pr(
+        self, logs: list[Dict[str, Any]], base_branch: str = "main"
+    ) -> Optional[int]:
+        """Create a shadow branch PR for the provided logs."""
+        import json
+        import subprocess
+        from hashlib import sha1
+        from pathlib import Path
+
+        diff_hash = sha1(json.dumps(logs, sort_keys=True).encode()).hexdigest()[:8]
+        branch = f"shadow-{diff_hash}"
+        if getattr(self.logger, "use_git", False):
+            repo = self.logger.repo_path
+            try:
+                current = subprocess.check_output(
+                    ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "HEAD"],
+                    text=True,
+                ).strip()
+                subprocess.run(
+                    ["git", "-C", str(repo), "checkout", "-b", branch],
+                    check=True,
+                )
+                fpath = Path(repo) / f"undo_{diff_hash}.json"
+                fpath.write_text(json.dumps(logs, indent=2))
+                subprocess.run(["git", "-C", str(repo), "add", fpath.name], check=True)
+                subprocess.run(
+                    ["git", "-C", str(repo), "commit", "-m", f"shadow {diff_hash}"],
+                    check=True,
+                )
+                subprocess.run(
+                    ["git", "-C", str(repo), "checkout", current], check=True
+                )
+            except Exception:
+                return None
+
+        pr_number = self.issue_manager.create_pull_request(
+            title=f"Undo operations {diff_hash}",
+            body=f"Automated undo operations\n\nDiff hash: `{diff_hash}`",
+            head=branch,
+            base=base_branch,
+        )
+        if pr_number and self.logger:
+            self.logger.log(
+                "shadow_pr",
+                {"hash": diff_hash, "pr": pr_number, "branch": branch},
+            )
+        return pr_number
+
+    def embed_diff_hash(self, pr_number: int, diff_hash: str) -> bool:
+        """Embed ``diff_hash`` as a comment on ``pr_number``."""
+        comment = f"diff-hash: `{diff_hash}`"
+        success = self.issue_manager.add_comment(pr_number, comment)
+        if success and self.logger:
+            self.logger.log(
+                "embed_diff_hash", {"pr": pr_number, "diff_hash": diff_hash}
+            )
+        return success

--- a/src/github/issue_manager.py
+++ b/src/github/issue_manager.py
@@ -400,6 +400,39 @@ class IssueManager:
             return False
 
     # ------------------------------------------------------------------
+    def create_pull_request(
+        self,
+        title: str,
+        body: str,
+        head: str,
+        base: str = "main",
+    ) -> Optional[int]:
+        """Create a pull request and return its number."""
+        try:
+            sess = self.session or requests
+            response = sess.post(
+                f"{self.base_url}/pulls",
+                headers=self.headers,
+                json={"title": title, "body": body, "head": head, "base": base},
+            )
+            if response.status_code in (200, 201):
+                pr = response.json()
+                if self.audit_logger:
+                    self.audit_logger.log(
+                        "create_pr",
+                        {
+                            "pr": pr.get("number"),
+                            "title": title,
+                            "head": head,
+                            "base": base,
+                        },
+                    )
+                return pr.get("number")
+        except Exception:
+            pass
+        return None
+
+    # ------------------------------------------------------------------
     def get_open_issues_count(self, repo: str | None = None) -> int:
         """Return the number of open issues for ``repo``."""
         try:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -7,9 +7,24 @@ from src.audit.undo import UndoManager
 class DummyIM:
     def __init__(self):
         self.labels = None
+        self.pr = None
+        self.comment = None
 
     def update_issue_labels(self, issue_number, add_labels=None, remove_labels=None):
         self.labels = (issue_number, add_labels, remove_labels)
+        return True
+
+    def create_pull_request(self, title, body, head, base="main"):
+        self.pr = {
+            "title": title,
+            "body": body,
+            "head": head,
+            "base": base,
+        }
+        return 1
+
+    def add_comment(self, issue_number, comment):
+        self.comment = (issue_number, comment)
         return True
 
 
@@ -62,3 +77,41 @@ def test_commit_window_limit(tmp_path: Path) -> None:
     # first hash should be out of window
     assert not undo.undo(hashes[0])
     assert undo.undo(hashes[2])
+
+
+def test_shadow_branch_pr(tmp_path: Path) -> None:
+    logger = AuditLogger(tmp_path / "audit.log", use_git=True)
+    dummy = DummyIM()
+    logger.log(
+        "update_labels", {"issue": 1, "add_labels": ["a"], "remove_labels": None}
+    )
+    logger.log("update_state", {"issue": 2, "new": "closed"})
+    logs = list(logger.iter_logs())
+    undo = UndoManager(dummy, logger)
+    pr = undo.create_shadow_branch_pr(logs)
+    assert pr == 1
+    assert dummy.pr and dummy.pr["head"].startswith("shadow-")
+    diff_hash = dummy.pr["head"].split("shadow-")[1]
+    import subprocess
+
+    files = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "ls-tree",
+            "-r",
+            "--name-only",
+            f"shadow-{diff_hash}",
+        ],
+        text=True,
+    )
+    assert f"undo_{diff_hash}.json" in files
+
+
+def test_embed_diff_hash(tmp_path: Path) -> None:
+    logger = AuditLogger(tmp_path / "audit.log")
+    dummy = DummyIM()
+    undo = UndoManager(dummy, logger)
+    assert undo.embed_diff_hash(2, "abcd1234")
+    assert dummy.comment == (2, "diff-hash: `abcd1234`")


### PR DESCRIPTION
## Summary
- extend `UndoManager` with `create_shadow_branch_pr` and `embed_diff_hash`
- support pull request creation in `IssueManager`
- test new undo shadow branch functionality

## Testing
- `flake8 --max-line-length=120 src tests`
- `pytest --no-cov tests/test_audit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6885bdeecb64832dbabb3808cf23e795