### PR TITLE
Implement Slack undo command handler

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -88,6 +88,7 @@ autonomy init --repo my-org/my-repo --autonomy-level supervised
 | Max Function Lines | `AUTONOMY_MAX_FUNCTION_LINES` | `40` | Maximum lines per function |
 | Test Coverage Target | `AUTONOMY_TEST_COVERAGE_TARGET` | `0.75` | Minimum test coverage (0.0-1.0) |
 | Human Approval | `AUTONOMY_REQUIRE_HUMAN_APPROVAL` | `true` | Require human approval for changes |
+| Commit Window | `AUTONOMY_COMMIT_WINDOW` | `5` | Number of operations that can be undone |
 
 ### Slack Configuration
 
@@ -161,6 +162,13 @@ export AUTONOMY_MAX_FUNCTION_LINES="40"
 
 # Set maximum PR size
 export AUTONOMY_MAX_PR_LINES="500"
+```
+
+### Undo System
+
+```bash
+# Limit undo to last 10 operations
+export AUTONOMY_COMMIT_WINDOW="10"
 ```
 
 ### Test Coverage

--- a/src/slack/commands.py
+++ b/src/slack/commands.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, List, Optional
 
 from .mapping import SlackGitHubMapper
+from .notifications import SystemNotifier, UndoOperation
 
 
 class SlashCommandHandler:
@@ -80,13 +82,22 @@ class SlashCommandHandler:
         blocks = [
             {
                 "type": "section",
-                "text": {"type": "mrkdwn", "text": f"*Status for {github_user}*"},
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Status for {github_user}*",
+                },
             },
             {
                 "type": "fields",
                 "fields": [
-                    {"type": "mrkdwn", "text": f"*Open Tasks:* {len(tasks)}"},
-                    {"type": "mrkdwn", "text": f"*In Progress:* {in_progress}"},
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Open Tasks:* {len(tasks)}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*In Progress:* {in_progress}",
+                    },
                 ],
             },
         ]
@@ -98,7 +109,7 @@ class SlashCommandHandler:
 
     def handle_undo_command(self, args: Dict) -> Dict:
         hash_value = args.get("text", "").strip()
-        if not hash_value:
+        if not hash_value or not re.fullmatch(r"[0-9a-f]{8}", hash_value):
             return {
                 "text": "Usage: `/autonomy undo <hash>`",
                 "response_type": "ephemeral",
@@ -111,12 +122,36 @@ class SlashCommandHandler:
 
         from src.audit.undo import UndoManager
 
-        undo = UndoManager(issue_mgr, logger)
-        if undo.undo(hash_value):
+        logs = list(logger.iter_logs())
+        if not any(
+            entry.get("hash") == hash_value or entry.get("diff_hash") == hash_value
+            for entry in logs
+        ):
             return {
-                "text": f"\u2705 Undo {hash_value} completed",
-                "response_type": "in_channel",
+                "text": f"Hash `{hash_value}` not found",
+                "response_type": "ephemeral",
             }
+
+        window = getattr(getattr(self.task_manager, "config", None), "commit_window", 5)
+        undo = UndoManager(issue_mgr, logger, commit_window=window)
+        if undo.undo(hash_value):
+            notifier: SystemNotifier | None = getattr(
+                self.task_manager, "system_notifier", None
+            )
+            if notifier:
+                channel = args.get("channel_id") or args.get("channel")
+                user = args.get("user_name") or args.get("user") or "unknown"
+                op = UndoOperation(
+                    description=f"Undo operation `{hash_value}`",
+                    actor=user,
+                    hash=hash_value,
+                )
+                if channel:
+                    notifier.send_undo_confirmation(channel, op)
+            msg = f"\u2705 Undo {hash_value} completed (window={window})"
+            if window > 10:
+                msg += " - large window"
+            return {"text": msg, "response_type": "in_channel"}
         return {
             "text": f"\u274c Undo {hash_value} failed",
             "response_type": "ephemeral",
@@ -161,8 +196,13 @@ class SlashCommandHandler:
                 "elements": [
                     {
                         "type": "button",
-                        "text": {"type": "plain_text", "text": "View on GitHub"},
-                        "url": f"https://github.com/{owner}/{repo}/issues/{issue['number']}",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "View on GitHub",
+                        },
+                        "url": (
+                            f"https://github.com/{owner}/{repo}/issues/{issue['number']}"
+                        ),
                     }
                 ],
             },

--- a/tests/test_autonomy_core.py
+++ b/tests/test_autonomy_core.py
@@ -50,6 +50,11 @@ class TestWorkflowConfig:
         loaded = WorkflowConfig.from_yaml(f)
         assert loaded.max_file_lines == 123
 
+    def test_env_commit_window(self, monkeypatch):
+        monkeypatch.setenv("AUTONOMY_COMMIT_WINDOW", "7")
+        cfg = WorkflowConfig.load_default()
+        assert cfg.commit_window == 7
+
 
 class TestAgents:
     """Test agent functionality."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -417,6 +417,20 @@ def test_cmd_audit_and_undo(tmp_path: Path):
     assert manager.issue_manager.labels == (1, [], ["a"])
 
 
+def test_cmd_undo_commit_window_override(tmp_path: Path):
+    manager = DummyManager(tmp_path)
+    h1 = manager.audit_logger.log(
+        "update_labels", {"issue": 1, "add_labels": ["a"], "remove_labels": None}
+    )
+    h2 = manager.audit_logger.log(
+        "update_labels", {"issue": 2, "add_labels": ["b"], "remove_labels": None}
+    )
+    args = SimpleNamespace(hash=h1, last=False, commit_window=1)
+    assert cmd_undo(manager, args) == 1
+    args.hash = h2
+    assert cmd_undo(manager, args) == 0
+
+
 def test_cmd_pin_unpin_and_list(monkeypatch, tmp_path: Path, capsys):
     manager = DummyManager(tmp_path)
 


### PR DESCRIPTION
## Summary
- validate hashes and check audit log before undo
- send confirmation via notifier when available
- test Slack undo handler edge cases
- add CLI flag and env override for commit window
- update docs and tests for commit window

## Testing
- `pre-commit run --files docs/CONFIGURATION.md src/cli/main.py src/core/config.py src/slack/commands.py tests/test_autonomy_core.py tests/test_cli_commands.py tests/test_slack_commands.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ccef6acc832d857fea67854d0108