### PR TITLE
Implement auto-sync for hierarchy on issue webhooks

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -155,6 +155,7 @@ def create_app(
             override_store,
             audit_logger=audit_logger,
             rate_limit=webhook_rate_limit,
+            task_manager=task_manager,
         )
     )
 


### PR DESCRIPTION
## Summary
- trigger hierarchy sync automatically when relevant issue webhooks arrive
- wire webhook router with task manager
- test webhook auto sync logic

## Testing
- `pre-commit run --files src/api/webhooks.py src/api/server.py tests/test_webhook.py`

------
https://chatgpt.com/codex/tasks/task_e_6885d3a4afb8832d9ea2159ca9068e19