### PR TITLE
Add commit window logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ autonomy board reorder
 autonomy hierarchy-sync
 ```
 
+**Undo Operations:**
+```bash
+# Undo the last change
+autonomy undo --last
+
+# Specify a custom commit window
+autonomy undo <hash> --commit-window 3
+```
+
 ---
 
 ## 🤝 Contributing

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -88,7 +88,7 @@ autonomy init --repo my-org/my-repo --autonomy-level supervised
 | Max Function Lines | `AUTONOMY_MAX_FUNCTION_LINES` | `40` | Maximum lines per function |
 | Test Coverage Target | `AUTONOMY_TEST_COVERAGE_TARGET` | `0.75` | Minimum test coverage (0.0-1.0) |
 | Human Approval | `AUTONOMY_REQUIRE_HUMAN_APPROVAL` | `true` | Require human approval for changes |
-| Commit Window | `AUTONOMY_COMMIT_WINDOW` | `5` | Number of operations that can be undone |
+| Commit Window | `AUTONOMY_COMMIT_WINDOW` | `5` | Number of operations that can be undone (override with `--commit-window`) |
 
 ### Slack Configuration
 
@@ -169,6 +169,9 @@ export AUTONOMY_MAX_PR_LINES="500"
 ```bash
 # Limit undo to last 10 operations
 export AUTONOMY_COMMIT_WINDOW="10"
+
+# Override for a single command
+autonomy undo --last --commit-window 3
 ```
 
 ### Test Coverage

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -255,6 +255,16 @@ autonomy metrics performance
 autonomy cache clear
 ```
 
+### Undo Operations
+
+```bash
+# Undo the last operation
+autonomy undo --last
+
+# Undo specific hash with custom window
+autonomy undo abcd1234 --commit-window 3
+```
+
 ### Debug Mode
 
 ```bash

--- a/src/audit/undo.py
+++ b/src/audit/undo.py
@@ -24,7 +24,17 @@ class UndoManager:
         logs = self._load_logs()
         for entry in reversed(logs):
             if entry.get("hash") == hash_value or entry.get("diff_hash") == hash_value:
-                return self._apply(entry)
+                success = self._apply(entry)
+                if success and self.logger:
+                    self.logger.log(
+                        "undo_operation",
+                        {
+                            "target_hash": entry.get("hash"),
+                            "diff_hash": entry.get("diff_hash"),
+                            "commit_window": self.commit_window,
+                        },
+                    )
+                return success
         return False
 
     def undo_last(self) -> Optional[str]:
@@ -33,6 +43,15 @@ class UndoManager:
             return None
         last = logs[-1]
         if self._apply(last):
+            if self.logger:
+                self.logger.log(
+                    "undo_operation",
+                    {
+                        "target_hash": last.get("hash"),
+                        "diff_hash": last.get("diff_hash"),
+                        "commit_window": self.commit_window,
+                    },
+                )
             return last.get("hash")
         return None
 


### PR DESCRIPTION
## Summary
- log undo operations with commit window metadata
- document commit window CLI override
- describe undo workflow usage in docs and README
- test undo logging

## Testing
- `pre-commit run --files src/audit/undo.py tests/test_audit.py docs/CONFIGURATION.md docs/USER_GUIDE.md README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d90552cc832db1627a60b8f143f3