### PR TITLE
Implement hierarchy auto-maintenance

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -38,6 +38,7 @@ def create_app(
 
     task_manager = TaskManager.__new__(TaskManager)
     task_manager.issue_manager = issue_manager
+    issue_manager.on_change = task_manager._trigger_sync
     from ..tasks.pinned_items import PinnedItemsStore
 
     task_manager.pinned_store = PinnedItemsStore()

--- a/src/tasks/task_manager.py
+++ b/src/tasks/task_manager.py
@@ -29,7 +29,11 @@ class TaskManager:
     ) -> None:
         self.config = config or WorkflowConfig()
         self.issue_manager = IssueManager(
-            github_token, owner, repo, audit_logger=audit_logger
+            github_token,
+            owner,
+            repo,
+            audit_logger=audit_logger,
+            on_change=self._trigger_sync,
         )
         self.audit_logger = audit_logger or getattr(
             self.issue_manager, "audit_logger", None

--- a/tests/test_issue_manager_hooks.py
+++ b/tests/test_issue_manager_hooks.py
@@ -1,0 +1,69 @@
+from src.github.issue_manager import IssueManager
+from src.tasks.task_manager import TaskManager
+
+
+class DummyResponse:
+    status_code = 200
+
+    def json(self):
+        return {}
+
+
+def _dummy_patch(*args, **kwargs):
+    return DummyResponse()
+
+
+def test_on_change_called_update_labels(monkeypatch):
+    called = {}
+    mgr = IssueManager(
+        "t",
+        "o",
+        "r",
+        on_change=lambda: called.setdefault("cnt", 0)
+        or called.update(cnt=called["cnt"] + 1),
+    )
+    monkeypatch.setattr(mgr, "get_issue", lambda n: {"labels": []})
+    monkeypatch.setattr("requests.patch", _dummy_patch)
+    assert mgr.update_issue_labels(1, add_labels=["x"]) is True
+    assert called.get("cnt", 0) == 1
+
+
+def test_on_change_called_update_state(monkeypatch):
+    called = {}
+    mgr = IssueManager(
+        "t",
+        "o",
+        "r",
+        on_change=lambda: called.setdefault("cnt", 0)
+        or called.update(cnt=called["cnt"] + 1),
+    )
+    monkeypatch.setattr("requests.patch", _dummy_patch)
+    assert mgr.update_issue_state(1, "closed") is True
+    assert called.get("cnt", 0) == 1
+
+
+def test_task_manager_auto_sync_on_issue_update(monkeypatch):
+    called = {}
+    tm = TaskManager("t", "o", "r")
+    tm.sync_cooldown = 0
+    tm._last_sync = 0
+    monkeypatch.setattr(tm.issue_manager, "get_issue", lambda n: {"labels": []})
+    monkeypatch.setattr("requests.patch", _dummy_patch)
+
+    def fake_sync(self):
+        called.setdefault("cnt", 0)
+        called["cnt"] += 1
+        return {"created": [], "orphans": []}
+
+    monkeypatch.setattr(
+        "src.tasks.hierarchy_manager.HierarchyManager.maintain_hierarchy",
+        fake_sync,
+    )
+    import types
+
+    monkeypatch.setattr(
+        "threading.Thread",
+        lambda target, daemon=False: types.SimpleNamespace(start=lambda: target()),
+    )
+    tm.issue_manager.update_issue_labels(1, add_labels=["x"])
+    assert called.get("cnt", 0) == 1


### PR DESCRIPTION
## Summary
- update `IssueManager` to accept `on_change` callback
- trigger hierarchy sync when issue updates occur
- wire auto-sync in `TaskManager` and API
- test issue manager hooks

## Testing
- `pre-commit run --files src/github/issue_manager.py src/tasks/task_manager.py src/api/server.py tests/test_issue_manager_hooks.py`

------
https://chatgpt.com/codex/tasks/task_e_6885dc3e8724832db82873703f3e5f38