### PR TITLE
Implement GitHub rate limit tracking

### DIFF
--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,3 +1,5 @@
+from requests.models import Response
+
 from src.core.errors import GitHubAPIError, handle_errors
 from src.github.client import ResilientGitHubClient
 
@@ -20,10 +22,12 @@ def test_resilient_github_client(monkeypatch):
     def fake_request(method, url, **kwargs):
         called["method"] = method
         called["url"] = url
-        return "ok"
+        resp = Response()
+        resp.status_code = 200
+        return resp
 
     monkeypatch.setattr(client.session, "request", fake_request)
     result = client.make_request("GET", "http://example.com")
-    assert result == "ok"
+    assert result.status_code == 200
     assert called["method"] == "GET"
     assert "example.com" in called["url"]

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -1,0 +1,45 @@
+from requests.models import Response
+
+from src.github.board_manager import GraphQLClient
+from src.github.client import ResilientGitHubClient
+
+
+def test_resilient_client_rate_limit(monkeypatch):
+    client = ResilientGitHubClient()
+
+    def fake_request(method, url, **kwargs):
+        resp = Response()
+        resp.status_code = 200
+        resp._content = b"{}"
+        resp.headers["X-RateLimit-Limit"] = "5000"
+        resp.headers["X-RateLimit-Remaining"] = "4999"
+        return resp
+
+    monkeypatch.setattr(client.session, "request", fake_request)
+    resp = client.make_request("GET", "http://example.com")
+    assert resp.status_code == 200
+    assert client.rate_limit_info["X-RateLimit-Limit"] == "5000"
+    assert client.rate_limit_info["X-RateLimit-Remaining"] == "4999"
+
+
+def test_graphql_client_cache(monkeypatch):
+    calls = []
+
+    def fake_make_request(self, method, url, **kwargs):
+        calls.append(1)
+        resp = Response()
+        resp.status_code = 200
+        resp._content = b'{"data": {"ok": true}}'
+        resp.headers["X-RateLimit-Remaining"] = "1"
+        self.rate_limit_info = {
+            "X-RateLimit-Remaining": "1",
+            "X-RateLimit-Limit": "5000",
+        }
+        return resp
+
+    monkeypatch.setattr(ResilientGitHubClient, "make_request", fake_make_request)
+    client = GraphQLClient("t", cache_ttl=10)
+    assert client.execute("query", {"v": 1}) == {"ok": True}
+    assert client.execute("query", {"v": 1}) == {"ok": True}
+    assert len(calls) == 1
+    assert client.rate_limit_info["X-RateLimit-Remaining"] == "1"


### PR DESCRIPTION
## Summary
- store GitHub rate limit headers on every request
- add caching and rate limit info to GraphQLClient
- test caching and rate limit tracking
- update existing tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688603ca3408832db2e93aecc7dc3855