### PR TITLE
Add coverage badge and performance benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,16 @@ jobs:
       - name: Install dependencies
         run: pip install -e .[dev]
       - name: Run full test suite
-        run: pytest -v --cov=src --cov-report=term-missing --cov-report=html
-      - name: Upload coverage
+        run: pytest -v --cov=src --cov-report=term-missing --cov-report=html --cov-report=xml
+      - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: htmlcov
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ https://autonomyhub.vercel.app
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![GitHub Actions](https://github.com/mehulbhardwaj/autonomy/workflows/CI/badge.svg)](https://github.com/mehulbhardwaj/autonomy/actions)
+[![codecov](https://codecov.io/gh/mehulbhardwaj/autonomy/branch/main/graph/badge.svg)](https://codecov.io/gh/mehulbhardwaj/autonomy)
 
 **Open source platform enabling humans + AI to collaborate for knowledge work** – An intelligent GitHub planning system with configurable AI agents that learn from your team's patterns and coordinate tasks across humans and specialized AI assistants.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ addopts = [
     "--cov=src",
     "--cov-report=term-missing",
     "--cov-report=html",
+    "--cov-report=xml",
     "--cov-fail-under=90",
     "-v"
 ]


### PR DESCRIPTION
## Summary
- measure TaskManager performance on large repo
- report coverage to Codecov in CI
- expose coverage badge in README
- generate coverage XML by default

## Testing
- `pre-commit run --files tests/test_performance.py README.md pyproject.toml .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68860a44f500832db24e4025c53a14bd