### PR TITLE
Add undo rate and audit metrics

### DIFF
--- a/src/metrics/collector.py
+++ b/src/metrics/collector.py
@@ -43,6 +43,7 @@ class MetricsCollector:
                 curr_wau, prev.get("weekly_active_users") if prev else None
             ),
             "override_rate": self.calculate_override_rate(),
+            "undo_rate": self.calculate_undo_rate(),
             "loc_per_assignee": self.calculate_loc_per_assignee(),
             "sprint_completion_rate": self.calculate_sprint_completion(),
             "open_issues_count": self.github.get_open_issues_count(repository),
@@ -97,6 +98,13 @@ class MetricsCollector:
         overrides = self.audit.count_human_overrides()
         return (overrides / total * 100) if total > 0 else 0.0
 
+    def calculate_undo_rate(self) -> float:
+        total = self.audit.count_ai_recommendations(days=7)
+        undos = 0
+        if hasattr(self.audit, "count_undo_operations"):
+            undos = self.audit.count_undo_operations(days=7)
+        return (undos / total * 100) if total > 0 else 0.0
+
     @staticmethod
     def calculate_trend(current: float, previous: float | None) -> float:
         if previous is None or previous == 0:
@@ -115,7 +123,8 @@ class MetricsCollector:
             f"**👥 Team Activity**\n"
             f"• Weekly active users: {metrics['weekly_active_users']} team members\n"
             f"• Planning commands used: {metrics['planning_commands_used']} today\n"
-            f"• Human overrides: {metrics['human_overrides_count']} (learning opportunities)\n\n"
+            f"• Human overrides: {metrics['human_overrides_count']} (learning opportunities)\n"
+            f"• Undo rate: {metrics['undo_rate']:.1f}%\n\n"
             f"**📈 Development Velocity**\n"
             f"• LOC per assignee: {metrics['loc_per_assignee']} avg\n"
             f"• Open issues: {metrics['open_issues_count']}\n"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -139,3 +139,21 @@ def test_undo_logs_entry(tmp_path: Path) -> None:
     details = undo_entry.get("details", {})
     assert details.get("target_hash") == h
     assert details.get("commit_window") == 3
+
+
+def test_audit_metrics_counts(tmp_path: Path) -> None:
+    logger = AuditLogger(tmp_path / "audit.log")
+    logger.log(
+        "tool_execute",
+        {"tool": "dummy", "action": "do", "agent": "a1", "success": True},
+    )
+    logger.log(
+        "tool_execute",
+        {"tool": "dummy", "action": "do", "agent": "a2", "success": False},
+    )
+    logger.log("undo_operation", {"target_hash": "abcd"})
+
+    assert logger.count_ai_recommendations() == 2
+    assert logger.count_approvals() == 1
+    assert logger.weekly_active_users() == 2
+    assert logger.count_undo_operations() == 1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -63,6 +63,7 @@ def test_metrics_collection_and_storage(tmp_path: Path) -> None:
     assert files
     data = json.loads(files[0].read_text())
     assert "orphan_issues_count" in data
+    assert "undo_rate" in data
 
 
 def test_storage_filters_personal_data(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- implement metrics counters in `AuditLogger`
- track undo rate in `MetricsCollector`
- extend Slack report with undo rate
- test new audit metrics helpers

## Testing
- `pre-commit run --files src/audit/logger.py src/metrics/collector.py tests/test_metrics.py tests/test_audit.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688643873698832d8a1d4c668c48c31f