### PR TITLE
Fix release workflow conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,25 +14,19 @@ on:
         options: [patch, minor, major]
 
 jobs:
-  version:
-    if: github.event_name == 'workflow_dispatch'
+  build-and-publish:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Bump version
+        if: github.event_name == 'workflow_dispatch'
         run: |
           ./scripts/bump-version.sh ${{ github.event.inputs.version_type }}
           ./scripts/release-notes.sh
           git push --follow-tags
-
-  build-and-publish:
-    runs-on: ubuntu-latest
-    needs: [version]
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
-    steps:
-      - uses: actions/checkout@v4
       
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- remove skipped `version` job and bump version directly in release workflow
- run release job on workflow dispatch, tag push or merges to main

## Testing
- `pip install -e '.[dev]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866f0faef4832da6a75800930faf30