### PR TITLE
Fix release workflow permissions and git identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
         type: choice
         options: [patch, minor, major]
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -21,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -30,12 +35,14 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
         env:
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
         run: |
           TYPE=${VERSION_TYPE:-patch}
           ./scripts/bump-version.sh "$TYPE"
           ./scripts/release-notes.sh
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
           git push --follow-tags
       
       - name: Set up Python


### PR DESCRIPTION
This PR fixes the release workflow by:

- Adding explicit write permissions for contents and packages
- Configuring git identity for GitHub Actions bot
- Adding proper token authentication for git push operations
- Setting fetch-depth to 0 for full git history access

Fixes the 'Permission denied' error when pushing version bumps and tags.